### PR TITLE
Add interactive machine learning pages

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ma bulle de recommandation - k-NN interactif</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: Verdana, sans-serif;
+      background: linear-gradient(to bottom, #5bc0eb, #20639b);
+      height: 100vh;
+      overflow: hidden;
+      position: relative;
+      opacity: 0;
+      animation: fadeIn 0.5s ease forwards;
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes fadeOut { from { opacity: 1; } to { opacity: 0; } }
+    .fade-out { animation: fadeOut 0.5s ease forwards; }
+    .container {
+      display: flex;
+      height: 100%;
+      padding: 1rem;
+      box-sizing: border-box;
+      position: relative;
+      z-index: 1;
+      gap: 1rem;
+    }
+    .panel {
+      flex: 1;
+      background: rgba(255,255,255,0.1);
+      border-radius: 8px;
+      padding: 1rem;
+      color: #fff;
+      overflow: auto;
+    }
+    h2 { margin-top: 0; font-size: 1.3rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td {
+      border: 1px solid rgba(255,255,255,0.3);
+      padding: 0.4rem;
+      text-align: left;
+    }
+    th { background: rgba(255,255,255,0.2); }
+    input[type=range] { width: 100%; }
+    .nav-bubble {
+      position: absolute;
+      top: 1rem;
+      width: 30px;
+      height: 30px;
+      background: rgba(255,255,255,0.2);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      backdrop-filter: blur(6px);
+      transition: background 0.2s;
+      z-index: 2;
+      color: #fff;
+      font-size: 1rem;
+    }
+    .nav-bubble:hover { background: rgba(255,255,255,0.3); }
+    .nav-left { right: 70px; }
+    .nav-right { right: 20px; }
+    .bubble-floating {
+      position: absolute;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.1);
+      animation: floatUp 30s linear infinite;
+      pointer-events: none;
+      backdrop-filter: blur(8px);
+      z-index: 0;
+    }
+    @keyframes floatUp { 0% { bottom: -100px; transform: translateX(0); } 100% { bottom: 110%; transform: translateX(50px); } }
+  </style>
+</head>
+<body>
+  <div class="nav-bubble nav-left" onclick="navigate('page2.html')">◀</div>
+  <div class="nav-bubble nav-right" onclick="navigate('page4.html')">▶</div>
+  <div class="container">
+    <div class="panel" id="panel1">
+      <h2>20 premières lignes</h2>
+      <table><thead><tr><th>Âge</th><th>Vidéo vue</th><th>Catégorie</th></tr></thead><tbody id="data-body"></tbody></table>
+    </div>
+    <div class="panel" id="panel2">
+      <h2>Paramètre k</h2>
+      <input type="range" id="k-slider" min="1" max="15" value="3"/>
+      <div>k = <span id="k-val">3</span></div>
+      <button id="train-btn">Entraîner</button>
+    </div>
+    <div class="panel" id="panel3">
+      <h2>Résultats</h2>
+      <canvas id="barChart" height="150"></canvas>
+      <table style="margin-top:1rem;"><thead><tr><th>Âge</th><th>Vidéo</th><th>Prédiction</th><th>Réel</th><th></th></tr></thead><tbody id="test-body"></tbody></table>
+    </div>
+  </div>
+  <div class="bubble-floating" style="left:10%;width:80px;height:80px;animation-delay:1s;"></div>
+  <div class="bubble-floating" style="left:30%;width:60px;height:60px;animation-delay:5s;"></div>
+  <div class="bubble-floating" style="left:50%;width:100px;height:100px;animation-delay:3s;"></div>
+  <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s;"></div>
+  <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s;"></div>
+  <script>
+    function navigate(url){
+      document.body.classList.add('fade-out');
+      document.body.addEventListener('animationend',()=>window.location.href=url,{once:true});
+    }
+    const titles=[
+      'Découverte d’un monde de blocs',
+      'Exploration d’un jeu d’énigmes',
+      'Recette de crêpes express',
+      'Tutoriel sur la préparation de smoothies',
+      'Présentation des tendances mode été',
+      'Interview d’un créateur de mode',
+      'Mon chat apprend un nouveau tour',
+      'Top 10 des animaux mignons',
+      'Test d’un nouveau jeu de sport',
+      'Vlog : ma journée sportive'
+    ];
+    const categories=['Gaming','Gaming','Cuisine','Cuisine','Mode','Mode','Animaux','Animaux','Sport','Sport'];
+    const dataset=[];
+    for(let i=0;i<50;i++){
+      const idx=i%titles.length;
+      dataset.push({age:10+(i%5),title:titles[idx],category:categories[idx],titleIndex:idx});
+    }
+    const dataBody=document.getElementById('data-body');
+    dataset.slice(0,20).forEach(d=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${d.age}</td><td>${d.title}</td><td>${d.category}</td>`;
+      dataBody.appendChild(tr);
+    });
+    const kSlider=document.getElementById('k-slider');
+    const kVal=document.getElementById('k-val');
+    kSlider.oninput=()=>kVal.textContent=kSlider.value;
+    let chart;
+    document.getElementById('train-btn').onclick=()=>{
+      const k=parseInt(kSlider.value);
+      const shuffled=[...dataset].sort(()=>Math.random()-0.5);
+      const split=Math.floor(shuffled.length*0.8);
+      const trainSet=shuffled.slice(0,split);
+      const testSet=shuffled.slice(split);
+      const cats=[...new Set(dataset.map(d=>d.category))];
+      const stats={}; cats.forEach(c=>stats[c]={correct:0,incorrect:0});
+      const examples=[];
+      testSet.forEach(sample=>{
+        const neighbors=trainSet.map(tr=>({
+          dist:Math.hypot(tr.age-sample.age,tr.titleIndex-sample.titleIndex),
+          category:tr.category
+        })).sort((a,b)=>a.dist-b.dist).slice(0,k);
+        const counts={};
+        neighbors.forEach(n=>counts[n.category]=(counts[n.category]||0)+1);
+        const pred=Object.keys(counts).reduce((a,b)=>counts[a]>counts[b]?a:b);
+        const correct=pred===sample.category;
+        stats[sample.category][correct?'correct':'incorrect']++;
+        if(examples.length<5)examples.push({...sample,pred,correct});
+      });
+      const labels=cats;
+      const correctData=labels.map(c=>stats[c].correct);
+      const incorrectData=labels.map(c=>stats[c].incorrect);
+      if(chart)chart.destroy();
+      chart=new Chart(document.getElementById('barChart'),{
+        type:'bar',
+        data:{labels,datasets:[
+          {label:'Correct',data:correctData,backgroundColor:'rgba(76,175,80,0.5)'},
+          {label:'Incorrect',data:incorrectData,backgroundColor:'rgba(244,67,54,0.5)'}
+        ]},
+        options:{scales:{y:{beginAtZero:true}}}
+      });
+      const testBody=document.getElementById('test-body');
+      testBody.innerHTML='';
+      examples.forEach(ex=>{
+        const row=document.createElement('tr');
+        row.innerHTML=`<td>${ex.age}</td><td>${ex.title}</td><td>${ex.pred}</td><td>${ex.category}</td><td>${ex.correct?'✔':'✖'}</td>`;
+        testBody.appendChild(row);
+      });
+    };
+  </script>
+</body>
+</html>

--- a/page4.html
+++ b/page4.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ma bulle de recommandation - TensorFlow.js</title>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.13.0/dist/tf.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { margin:0; padding:0; font-family: Verdana, sans-serif; background: linear-gradient(to bottom, #5bc0eb, #20639b); height:100vh; overflow:hidden; position:relative; opacity:0; animation:fadeIn 0.5s ease forwards; }
+    @keyframes fadeIn { from{opacity:0;} to{opacity:1;} }
+    @keyframes fadeOut { from{opacity:1;} to{opacity:0;} }
+    .fade-out{animation:fadeOut 0.5s ease forwards;}
+    .container{display:flex; height:100%; padding:1rem; box-sizing:border-box; position:relative; z-index:1; gap:1rem;}
+    .panel{flex:1; background:rgba(255,255,255,0.1); border-radius:8px; padding:1rem; color:#fff; overflow:auto;}
+    h2{margin-top:0; font-size:1.3rem;}
+    input[type=range]{width:100%;}
+    .nav-bubble{position:absolute; top:1rem; width:30px; height:30px; background:rgba(255,255,255,0.2); border-radius:50%; display:flex; align-items:center; justify-content:center; cursor:pointer; backdrop-filter:blur(6px); transition:background 0.2s; z-index:2; color:#fff; font-size:1rem;}
+    .nav-bubble:hover{background:rgba(255,255,255,0.3);}
+    .nav-left{right:70px;}
+    .nav-right{right:20px;}
+    .bubble-floating{position:absolute; border-radius:50%; background:rgba(255,255,255,0.1); animation:floatUp 30s linear infinite; pointer-events:none; backdrop-filter:blur(8px); z-index:0;}
+    @keyframes floatUp{0%{bottom:-100px;transform:translateX(0);}100%{bottom:110%;transform:translateX(50px);}}
+  </style>
+</head>
+<body>
+  <div class="nav-bubble nav-left" onclick="navigate('page3.html')">◀</div>
+  <div class="nav-bubble nav-right" onclick="navigate('page5.html')">▶</div>
+  <div class="container">
+    <div class="panel">
+      <h2>Entraînement</h2>
+      <input type="range" id="epoch-slider" min="1" max="50" value="10"/>
+      <div>Époques : <span id="epoch-val">10</span></div>
+      <button id="train-btn">Lancer</button>
+      <div id="accuracy">Accuracy : -</div>
+    </div>
+    <div class="panel">
+      <h2>Loss</h2>
+      <canvas id="lossChart" height="200"></canvas>
+    </div>
+  </div>
+  <div class="bubble-floating" style="left:10%;width:80px;height:80px;animation-delay:1s;"></div>
+  <div class="bubble-floating" style="left:30%;width:60px;height:60px;animation-delay:5s;"></div>
+  <div class="bubble-floating" style="left:50%;width:100px;height:100px;animation-delay:3s;"></div>
+  <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s;"></div>
+  <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s;"></div>
+  <script>
+    function navigate(url){
+      document.body.classList.add('fade-out');
+      document.body.addEventListener('animationend',()=>window.location.href=url,{once:true});
+    }
+    const titles=['Découverte d’un monde de blocs','Exploration d’un jeu d’énigmes','Recette de crêpes express','Tutoriel sur la préparation de smoothies','Présentation des tendances mode été','Interview d’un créateur de mode','Mon chat apprend un nouveau tour','Top 10 des animaux mignons','Test d’un nouveau jeu de sport','Vlog : ma journée sportive'];
+    const categories=['Gaming','Gaming','Cuisine','Cuisine','Mode','Mode','Animaux','Animaux','Sport','Sport'];
+    const dataset=[];
+    for(let i=0;i<50;i++){const idx=i%titles.length;dataset.push({age:10+(i%5),titleIndex:idx,category:categories[idx]});}
+    const epochSlider=document.getElementById('epoch-slider');
+    const epochVal=document.getElementById('epoch-val');
+    epochSlider.oninput=()=>epochVal.textContent=epochSlider.value;
+    let lineChart;
+    function prepareData(){
+      const shuffled=[...dataset].sort(()=>Math.random()-0.5);
+      const split=Math.floor(shuffled.length*0.8);
+      const train=shuffled.slice(0,split);
+      const test=shuffled.slice(split);
+      const catList=[...new Set(categories)];
+      const labelMap={};catList.forEach((c,i)=>labelMap[c]=i);
+      const toTensors=data=>{
+        const xs=data.map(d=>[d.age,d.titleIndex]);
+        const ys=data.map(d=>labelMap[d.category]);
+        return {x:tf.tensor2d(xs),y:tf.tensor1d(ys,'int32')};
+      };
+      const {x:trainX,y:trainY}=toTensors(train);
+      const {x:testX,y:testY}=toTensors(test);
+      return {trainX,trainY,testX,testY,numClasses:catList.length};
+    }
+    async function trainModel(){
+      const epochs=parseInt(epochSlider.value);
+      const {trainX,trainY,testX,testY,numClasses}=prepareData();
+      const model=tf.sequential();
+      model.add(tf.layers.dense({inputShape:[2],units:8,activation:'relu'}));
+      model.add(tf.layers.dense({units:numClasses,activation:'softmax'}));
+      model.compile({optimizer:'adam',loss:'sparseCategoricalCrossentropy',metrics:['accuracy']});
+      const losses=[];
+      await model.fit(trainX,trainY,{
+        epochs,
+        validationData:[testX,testY],
+        callbacks:{onEpochEnd:(epoch,logs)=>{
+          losses.push({epoch:epoch+1,loss:logs.loss});
+          const labels=losses.map(l=>l.epoch);
+          const data=losses.map(l=>l.loss);
+          if(lineChart) lineChart.destroy();
+          lineChart=new Chart(document.getElementById('lossChart'),{type:'line',data:{labels,datasets:[{label:'Loss',data,borderColor:'#fff',fill:false}]},options:{scales:{y:{beginAtZero:true}}}});
+        }}
+      });
+      const evalRes=await model.evaluate(testX,testY);
+      const acc=await evalRes[1].data();
+      document.getElementById('accuracy').textContent=`Accuracy : ${(acc[0]*100).toFixed(1)}%`;
+      window.trainedModel=model;
+    }
+    document.getElementById('train-btn').onclick=trainModel;
+  </script>
+</body>
+</html>

--- a/page5.html
+++ b/page5.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ma bulle de recommandation - Test utilisateur</title>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.13.0/dist/tf.min.js"></script>
+  <style>
+    body{margin:0;padding:0;font-family:Verdana,sans-serif;background:linear-gradient(to bottom,#5bc0eb,#20639b);height:100vh;overflow:hidden;position:relative;opacity:0;animation:fadeIn 0.5s ease forwards;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+    @keyframes fadeOut{from{opacity:1;}to{opacity:0;}}
+    .fade-out{animation:fadeOut 0.5s ease forwards;}
+    .container{display:flex;height:100%;padding:1rem;box-sizing:border-box;position:relative;z-index:1;gap:1rem;}
+    .panel{flex:1;background:rgba(255,255,255,0.1);border-radius:8px;padding:1rem;color:#fff;overflow:auto;}
+    h2{margin-top:0;font-size:1.3rem;}
+    label{display:block;margin-top:0.5rem;}
+    select,input{width:100%;padding:0.3rem;margin-top:0.2rem;}
+    button{margin-top:0.8rem;padding:0.5rem 1rem;border:none;border-radius:4px;background:rgba(255,255,255,0.2);color:#fff;cursor:pointer;}
+    button:hover{background:rgba(255,255,255,0.3);}
+    .nav-bubble{position:absolute;top:1rem;width:30px;height:30px;background:rgba(255,255,255,0.2);border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;backdrop-filter:blur(6px);transition:background 0.2s;z-index:2;color:#fff;font-size:1rem;}
+    .nav-bubble:hover{background:rgba(255,255,255,0.3);}
+    .nav-left{right:70px;}
+    .nav-right{right:20px;}
+    .bubble-floating{position:absolute;border-radius:50%;background:rgba(255,255,255,0.1);animation:floatUp 30s linear infinite;pointer-events:none;backdrop-filter:blur(8px);z-index:0;}
+    @keyframes floatUp{0%{bottom:-100px;transform:translateX(0);}100%{bottom:110%;transform:translateX(50px);}}
+  </style>
+</head>
+<body>
+  <div class="nav-bubble nav-left" onclick="navigate('page4.html')">◀</div>
+  <div class="nav-bubble nav-right" onclick="navigate('page6.html')">▶</div>
+  <div class="container">
+    <div class="panel">
+      <h2>Tester le modèle</h2>
+      <label>Âge
+        <input type="number" id="age-input" min="5" max="99">
+      </label>
+      <label>Vidéo regardée
+        <select id="title-select"></select>
+      </label>
+      <button id="predict-btn">Prédire</button>
+      <div id="prediction" style="margin-top:1rem;"></div>
+      <div id="feedback" style="margin-top:1rem;display:none;">
+        Cette prédiction est-elle correcte ?
+        <button id="fb-correct">Correct</button>
+        <button id="fb-wrong">Pas correct</button>
+      </div>
+    </div>
+    <div class="panel">
+      <h2>Score</h2>
+      <div id="score">Correct: 0 | Pas correct: 0</div>
+    </div>
+  </div>
+  <div class="bubble-floating" style="left:10%;width:80px;height:80px;animation-delay:1s;"></div>
+  <div class="bubble-floating" style="left:30%;width:60px;height:60px;animation-delay:5s;"></div>
+  <div class="bubble-floating" style="left:50%;width:100px;height:100px;animation-delay:3s;"></div>
+  <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s;"></div>
+  <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s;"></div>
+  <script>
+    function navigate(url){document.body.classList.add('fade-out');document.body.addEventListener('animationend',()=>window.location.href=url,{once:true});}
+    const titles=['Découverte d’un monde de blocs','Exploration d’un jeu d’énigmes','Recette de crêpes express','Tutoriel sur la préparation de smoothies','Présentation des tendances mode été','Interview d’un créateur de mode','Mon chat apprend un nouveau tour','Top 10 des animaux mignons','Test d’un nouveau jeu de sport','Vlog : ma journée sportive'];
+    const categories=['Gaming','Gaming','Cuisine','Cuisine','Mode','Mode','Animaux','Animaux','Sport','Sport'];
+    const dataset=[];for(let i=0;i<50;i++){const idx=i%titles.length;dataset.push({age:10+(i%5),titleIndex:idx,category:categories[idx]});}
+    const titleSelect=document.getElementById('title-select');
+    titles.forEach((t,i)=>{const opt=document.createElement('option');opt.value=i;opt.textContent=t;titleSelect.appendChild(opt);});
+    function prepareData(){const shuffled=[...dataset].sort(()=>Math.random()-0.5);const split=Math.floor(shuffled.length*0.8);const train=shuffled.slice(0,split);const test=shuffled.slice(split);const catList=[...new Set(categories)];const labelMap={};catList.forEach((c,i)=>labelMap[c]=i);const toTensors=data=>{const xs=data.map(d=>[d.age,d.titleIndex]);const ys=data.map(d=>labelMap[d.category]);return{ x:tf.tensor2d(xs), y:tf.tensor1d(ys,'int32') };};const {x:trainX,y:trainY}=toTensors(train);const {x:testX,y:testY}=toTensors(test);return{trainX,trainY,testX,testY,numClasses:catList.length,labelMap,catList};}
+    let model;let labelMap;let catList;
+    async function train(){const data=prepareData();labelMap=data.labelMap;catList=data.catList;model=tf.sequential();model.add(tf.layers.dense({inputShape:[2],units:8,activation:'relu'}));model.add(tf.layers.dense({units:data.numClasses,activation:'softmax'}));model.compile({optimizer:'adam',loss:'sparseCategoricalCrossentropy',metrics:['accuracy']});await model.fit(data.trainX,data.trainY,{epochs:20});}
+    train();
+    const ageInput=document.getElementById('age-input');
+    const predictionDiv=document.getElementById('prediction');
+    const feedbackDiv=document.getElementById('feedback');
+    const scoreDiv=document.getElementById('score');
+    let currentPrediction=null;let correct=0;let incorrect=0;
+    document.getElementById('predict-btn').onclick=async()=>{const age=parseInt(ageInput.value);const titleIdx=parseInt(titleSelect.value);if(isNaN(age))return;const pred=model.predict(tf.tensor2d([[age,titleIdx]]));const idx=pred.argMax(-1).dataSync()[0];currentPrediction=catList[idx];predictionDiv.textContent='Prédiction : '+currentPrediction;feedbackDiv.style.display='block';};
+    function record(isCorrect){if(isCorrect)correct++;else incorrect++;scoreDiv.textContent=`Correct: ${correct} | Pas correct: ${incorrect}`;const stored=JSON.parse(localStorage.getItem('feedback')||'[]');stored.push({age:parseInt(ageInput.value),category:currentPrediction,correct:isCorrect});localStorage.setItem('feedback',JSON.stringify(stored));feedbackDiv.style.display='none';}
+    document.getElementById('fb-correct').onclick=()=>record(true);
+    document.getElementById('fb-wrong').onclick=()=>record(false);
+  </script>
+</body>
+</html>

--- a/page6.html
+++ b/page6.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ma bulle de recommandation - Réflexion</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body{margin:0;padding:0;font-family:Verdana,sans-serif;background:linear-gradient(to bottom,#5bc0eb,#20639b);height:100vh;overflow:hidden;position:relative;opacity:0;animation:fadeIn 0.5s ease forwards;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+    @keyframes fadeOut{from{opacity:1;}to{opacity:0;}}
+    .fade-out{animation:fadeOut 0.5s ease forwards;}
+    .container{display:flex;height:100%;padding:1rem;box-sizing:border-box;position:relative;z-index:1;gap:1rem;}
+    .panel{flex:1;background:rgba(255,255,255,0.1);border-radius:8px;padding:1rem;color:#fff;overflow:auto;}
+    h2{margin-top:0;font-size:1.3rem;}
+    .card{background:rgba(255,255,255,0.1);border-radius:8px;padding:0.5rem;margin:0.5rem 0;}
+    a{color:#fff;}
+    .nav-bubble{position:absolute;top:1rem;width:30px;height:30px;background:rgba(255,255,255,0.2);border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;backdrop-filter:blur(6px);transition:background 0.2s;z-index:2;color:#fff;font-size:1rem;}
+    .nav-bubble:hover{background:rgba(255,255,255,0.3);}
+    .nav-left{right:70px;}
+    .nav-right{right:20px;}
+    .bubble-floating{position:absolute;border-radius:50%;background:rgba(255,255,255,0.1);animation:floatUp 30s linear infinite;pointer-events:none;backdrop-filter:blur(8px);z-index:0;}
+    @keyframes floatUp{0%{bottom:-100px;transform:translateX(0);}100%{bottom:110%;transform:translateX(50px);}}
+  </style>
+</head>
+<body>
+  <div class="nav-bubble nav-left" onclick="navigate('page5.html')">◀</div>
+  <div class="nav-bubble nav-right" onclick="navigate('index.html')">▶</div>
+  <div class="container">
+    <div class="panel">
+      <h2>Erreurs</h2>
+      <canvas id="catChart" height="150"></canvas>
+      <canvas id="ageChart" height="150" style="margin-top:1rem;"></canvas>
+    </div>
+    <div class="panel">
+      <h2>Réflexion</h2>
+      <div class="card">Pourquoi plus d’erreurs sur certaines catégories ?</div>
+      <div class="card">Comment notre dataset pourrait-il être biaisé ?</div>
+      <div class="card">Que feriez-vous pour améliorer les données ?</div>
+      <a href="https://fr.wikipedia.org/wiki/Biais_de_s%C3%A9lection" target="_blank">En savoir plus sur les biais de données</a>
+    </div>
+  </div>
+  <div class="bubble-floating" style="left:10%;width:80px;height:80px;animation-delay:1s;"></div>
+  <div class="bubble-floating" style="left:30%;width:60px;height:60px;animation-delay:5s;"></div>
+  <div class="bubble-floating" style="left:50%;width:100px;height:100px;animation-delay:3s;"></div>
+  <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s;"></div>
+  <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s;"></div>
+  <script>
+    function navigate(url){document.body.classList.add('fade-out');document.body.addEventListener('animationend',()=>window.location.href=url,{once:true});}
+    const stored=JSON.parse(localStorage.getItem('feedback')||'[]');
+    const catErrors={};const ageErrors={'10-12':0,'13-14':0};
+    stored.forEach(r=>{if(!r.correct){catErrors[r.category]=(catErrors[r.category]||0)+1;const range=r.age<=12?'10-12':'13-14';ageErrors[range]=(ageErrors[range]||0)+1;}});
+    new Chart(document.getElementById('catChart'),{type:'bar',data:{labels:Object.keys(catErrors),datasets:[{label:'Erreurs',data:Object.values(catErrors),backgroundColor:'rgba(244,67,54,0.5)'}]},options:{scales:{y:{beginAtZero:true}}}});
+    new Chart(document.getElementById('ageChart'),{type:'bar',data:{labels:Object.keys(ageErrors),datasets:[{label:'Erreurs',data:Object.values(ageErrors),backgroundColor:'rgba(244,67,54,0.5)'}]},options:{scales:{y:{beginAtZero:true}}}});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add interactive k-NN demo with adjustable k and result chart
- Introduce TensorFlow.js training page with epoch slider and loss graph
- Enable user prediction test with feedback tracking
- Provide reflection page showing error charts and bias prompts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68939b8985388331b5f67319c6e22132