### PR TITLE
Persist decision tree state across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,10 @@
   <script>
     document.getElementById('start-btn').addEventListener('click', () => {
       document.body.classList.add('fade-out');
-      document.body.addEventListener('animationend', () => window.location.href='page1.html', { once: true });
+      document.body.addEventListener('animationend', () => {
+        const target = 'page1.html' + location.hash;
+        window.location.href = target;
+      }, { once: true });
     });
   </script>
 </body>

--- a/page1.html
+++ b/page1.html
@@ -131,7 +131,8 @@
   <script>
     function navigate(url) {
       document.body.classList.add('fade-out');
-      document.body.addEventListener('animationend', () => window.location.href = url, { once: true });
+      const dest = url + location.hash;
+      document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
     const questions = [
       { age: 11, watched: 'Découverte d’un monde de blocs', category: 'Jeux', options: ['Top des nouveautés ludiques','Recette facile de gâteaux','Daily vlog scolaire','Astuces de soins pour animaux'] },

--- a/page2.html
+++ b/page2.html
@@ -107,7 +107,8 @@
   <script>
     function navigate(url) {
       document.body.classList.add('fade-out');
-      document.body.addEventListener('animationend', () => window.location.href = url, { once: true });
+      const dest = url + location.hash;
+      document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
     function removeRow(btn) {
       const row = btn.closest('tr');

--- a/page3.html
+++ b/page3.html
@@ -141,8 +141,10 @@
 
   <script>
     function navigate(url) {
+      saveState();
       document.body.classList.add('fade-out');
-      document.body.addEventListener('animationend', () => window.location.href = url, { once: true });
+      const dest = url + location.hash;
+      document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
 
 

--- a/page4.html
+++ b/page4.html
@@ -42,7 +42,11 @@ th{background:rgba(255,255,255,.2)}
   </div>
 </div>
 <script>
-function navigate(u){document.body.classList.add('fade-out');document.body.addEventListener('animationend',()=>location.href=u,{once:true})}
+function navigate(u){
+ document.body.classList.add('fade-out');
+ const dest=u+location.hash;
+ document.body.addEventListener('animationend',()=>location.href=dest,{once:true})
+}
 function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
 const trainData=[
 {title:'Moments drôles du castor bleu',label:'Dessins'},

--- a/page5.html
+++ b/page5.html
@@ -72,7 +72,8 @@
   <script>
     function navigate(url) {
       document.body.classList.add('fade-out');
-      document.body.addEventListener('animationend', () => window.location.href = url, { once: true });
+      const dest = url + location.hash;
+      document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Preserve decision-tree state by appending the current URL hash to navigation on all pages
- Ensure page 3 saves the tree before leaving so the latest state persists

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed468c388331aa6ccdad3daa53c5