### PR TITLE
feat: add real model demo to page5

### DIFF
--- a/page5.html
+++ b/page5.html
@@ -105,11 +105,13 @@
     <div class="panel">
       <h2>Arbre de Décision</h2>
       <div id="cy"></div>
+      <div id="current-title"></div>
       <div class="choices">
-        <button onclick="vote('A')">Choix A</button>
-        <button onclick="vote('B')">Choix B</button>
-        <button onclick="vote('C')">Choix C</button>
-        <button onclick="vote('D')">Choix D</button>
+        <button onclick="vote('Dessins')">Dessins</button>
+        <button onclick="vote('Expériences')">Expériences</button>
+        <button onclick="vote('Animaux')">Animaux</button>
+        <button onclick="vote('Sciences')">Sciences</button>
+        <button onclick="vote('Jeux vidéo')">Jeux vidéo</button>
       </div>
       <div class="counter">✅: <span id="user-correct">0</span></div>
     </div>
@@ -167,17 +169,98 @@
     }
     loadTree();
 
-    // Dummy choices & counters
-    let modelCorrect = 0, userCorrect = 0;
-    function vote(choice) {
-      const isCorrect = Math.random() < 0.5;
-      if (isCorrect) userCorrect++;
-      document.getElementById('user-correct').textContent = userCorrect;
-      // Simulate model prediction and update its counter if correct
-      const modelIsCorrect = Math.random() < 0.5;
-      if (modelIsCorrect) modelCorrect++;
-      document.getElementById('model-correct').textContent = modelCorrect;
+    // --- Données d'entraînement et modèle ---
+    function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
+    const trainData=[
+      {title:'Moments drôles du castor bleu',label:'Dessins'},
+      {title:'La course folle du lapin malin',label:'Dessins'},
+      {title:'La flaque de boue magique',label:'Dessins'},
+      {title:'Le coureur et le coyote rigolo',label:'Dessins'},
+      {title:'Aventure au chalet des amis',label:'Dessins'},
+      {title:'Blagues du duo farceur',label:'Dessins'},
+      {title:'Sauvetage dans la forêt mystique',label:'Dessins'},
+      {title:'Patrouille du port joyeux',label:'Dessins'},
+      {title:'Fête de danse des chiots',label:'Dessins'},
+      {title:'La montagne russe bricolée',label:'Dessins'},
+      {title:'Volcan maison avec vinaigre',label:'Expériences'},
+      {title:'Fusée au bicarbonate de soude',label:'Expériences'},
+      {title:'Réaction pâte à dents géante',label:'Expériences'},
+      {title:'Fabriquer du slime étirable',label:'Expériences'},
+      {title:'Lait qui change de couleur',label:'Expriences'},
+      {title:'Oobleck étrange liquide‑solide',label:'Expériences'},
+      {title:'Voiture ballon propulsée',label:'Expériences'},
+      {title:'Lampe lave DIY',label:'Expériences'},
+      {title:'Pile citron maison',label:'Expériences'},
+      {title:'Fontaine menthe et cola',label:'Expériences'},
+      {title:'Premiers pas du panda roux',label:'Animaux'},
+      {title:'Safari rugissements du lion',label:'Animaux'},
+      {title:'Chiens exécutent des tours',label:'Animaux'},
+      {title:'Chatons jouent au laser',label:'Animaux'},
+      {title:'Sauts spectaculaires des dauphins',label:'Animaux'},
+      {title:'Danse des oiseaux tropicaux',label:'Animaux'},
+      {title:'Vie secrète des fourmis',label:'Animaux'},
+      {title:'Sauvetage d’un manchot',label:'Animaux'},
+      {title:'Bain de boue de l’éléphant',label:'Animaux'},
+      {title:'Grimpe du panda roux',label:'Animaux'},
+      {title:'Le système solaire expliqué',label:'Sciences'},
+      {title:'Pourquoi les plantes sont vertes',label:'Sciences'},
+      {title:'Physique des montagnes russes',label:'Sciences'},
+      {title:'Voyage dans le corps humain',label:'Sciences'},
+      {title:'Construire un circuit simple',label:'Sciences'},
+      {title:'Cycle de l’eau illustré',label:'Sciences'},
+      {title:'Bases du magnétisme',label:'Sciences'},
+      {title:'Les états de la matière',label:'Sciences'},
+      {title:'Documentaire sur les dinosaures',label:'Sciences'},
+      {title:'Introduction à l’électricité',label:'Sciences'},
+      {title:'Guide débutant de l’île pixel',label:'Jeux vidéo'},
+      {title:'Course folle de kart arctique',label:'Jeux vidéo'},
+      {title:'Construction d’un monde en blocs',label:'Jeux vidéo'},
+      {title:'Défi danse rythmique arcade',label:'Jeux vidéo'},
+      {title:'Stratégie conquête médiévale',label:'Jeux vidéo'},
+      {title:'Aventure RPG forêt enchantée',label:'Jeux vidéo'},
+      {title:'Match de soccer virtuel',label:'Jeux vidéo'},
+      {title:'Puzzle plateforme spatiale',label:'Jeux vidéo'},
+      {title:'Course à obstacles néon',label:'Jeux vidéo'},
+      {title:'Simulation ferme canadienne',label:'Jeux vidéo'}
+    ];
+    const testData=[
+      {title:'Bataille de robots rétro',label:'Jeux vidéo'},
+      {title:'Expérience œuf rebondissant',label:'Expériences'},
+      {title:'Pourquoi avons‑nous des saisons',label:'Sciences'},
+      {title:'Premiers pas du koala',label:'Animaux'}
+    ];
+    const recVid={Dessins:'Aventure au chalet des amis',Expériences:'Réaction pâte à dents géante',Animaux:'Premiers pas du panda roux',Sciences:'Le système solaire expliqué','Jeux vidéo':'Construction d’un monde en blocs'};
+    let vocab=[],word2idx={},centroids={},centroidNorm={};
+    function buildVocab(){for(const r of trainData){for(const w of tokens(r.title)){if(word2idx[w]===undefined){word2idx[w]=vocab.length;vocab.push(w)}}}}
+    function vecFromTitle(t){const v=new Uint8Array(vocab.length);for(const w of tokens(t)){const i=word2idx[w];if(i!==undefined)v[i]=1}return v}
+    function cosine(a,b,nB){let dot=0,nA=0;for(let i=0;i<a.length;i++){if(a[i]){nA++;if(b[i])dot++}}if(nA===0||nB===0)return 0;return dot/Math.sqrt(nA*nB)}
+    function trainModel(){buildVocab();const sums={},counts={};for(const r of trainData){const v=vecFromTitle(r.title);const lab=r.label;if(!sums[lab]){sums[lab]=new Float32Array(vocab.length);counts[lab]=0}for(let i=0;i<v.length;i++){sums[lab][i]+=v[i]}counts[lab]++}for(const lab in sums){for(let i=0;i<vocab.length;i++){sums[lab][i]/=counts[lab]}centroids[lab]=sums[lab];let n=0;for(let i=0;i<vocab.length;i++){if(centroids[lab][i]>0)n++}centroidNorm[lab]=Math.sqrt(n)}}
+    function predict(t){const v=vecFromTitle(t);let best=null,bestScore=-1;for(const lab in centroids){const s=cosine(v,centroids[lab],centroidNorm[lab]);if(s>bestScore){bestScore=s;best=lab}}return best}
+
+    let modelCorrect=0,userCorrect=0,currentTest=0;
+    trainModel();
+    function showTest(){
+      if(currentTest>=testData.length){
+        document.getElementById('current-title').textContent='Fin des tests';
+        document.getElementById('model-pred').textContent='Terminé';
+        document.querySelector('.choices').innerHTML='';
+        return;
+      }
+      const t=testData[currentTest];
+      document.getElementById('current-title').textContent=`Visionné : ${t.title}`;
+      const cat=predict(t.title);
+      const suggestion=recVid[cat]||'Aucune';
+      document.getElementById('model-pred').innerHTML=`Suggestion : <strong>${suggestion}</strong>`;
+      if(cat===t.label){modelCorrect++;document.getElementById('model-correct').textContent=modelCorrect;}
     }
+    function vote(cat){
+      if(currentTest>=testData.length)return;
+      const t=testData[currentTest];
+      if(cat===t.label){userCorrect++;document.getElementById('user-correct').textContent=userCorrect;}
+      currentTest++;
+      showTest();
+    }
+    showTest();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder quiz in page5 with real video-category model
- show test video titles, model suggestions and track correctness for model vs. user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f23132d08331938e174df94fa8bc