### PR TITLE
Persist decision tree and compute leaf predictions

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -99,6 +99,15 @@
       background: #fff;
     }
 
+    #nodeModal {
+      position: absolute; display: none;
+      z-index: 10; background: #fff;
+      border: 1px solid #aaa; padding: 8px;
+      border-radius: 4px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    }
+    #nodeModal label { display: block; margin: 4px 0; }
+
     .bubble-floating {
       position: absolute; border-radius: 50%;
       background: rgba(255,255,255,0.1);
@@ -128,6 +137,11 @@
     </div>
     <div id="cy"></div>
     <input id="labelEditor" type="text" />
+    <div id="nodeModal">
+      <label>Champ: <select id="fieldSelect"></select></label>
+      <label>Seuil: <input id="thresholdInput" type="number"/></label>
+      <div><button id="modalOk">OK</button><button id="modalCancel">Annuler</button></div>
+    </div>
     <div id="trash" title="Glissez ici pour supprimer"></div>
 
   </div>
@@ -146,7 +160,16 @@
       const dest = url + location.hash;
       document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
-
+    const videos = (()=>{
+      try {
+        const v = localStorage.getItem('videosClean') || localStorage.getItem('videos');
+        return v ? JSON.parse(v) : [];
+      } catch(e){ return []; }
+    })();
+    const fieldSelect = document.getElementById('fieldSelect');
+    if(videos[0]) Object.keys(videos[0]).forEach(k => {
+      const o=document.createElement('option'); o.value=k; o.textContent=k; fieldSelect.appendChild(o);
+    });
 
     const cy = cytoscape({
       container: document.getElementById('cy'),
@@ -181,7 +204,49 @@
     });
 
     let nextNodeId = 0, nextEdgeId = 0;
+    function matchesExample(v, leaf){
+      let cur=leaf;
+      while(true){
+        const inc=cur.incoming('edge');
+        if(!inc.length) break;
+        const e=inc[0], parent=e.source();
+        const f=parent.data('field'), thr=parent.data('threshold');
+        if(f==null || thr==null) return false;
+        const dir=e.data('dir');
+        const val=Number(v[f]);
+        if(dir===0){ if(!(val<=thr)) return false; }
+        else { if(!(val>thr)) return false; }
+        cur=parent;
+      }
+      return true;
+    }
+    function refreshLeaves(){
+      cy.nodes('.leaf').forEach(n=>{
+        if(!videos.length) return;
+        const matched=videos.filter(v=>matchesExample(v,n));
+        if(!matched.length) return;
+        const counts={};
+        matched.forEach(v=>{counts[v.id]=(counts[v.id]||0)+1;});
+        let best=null, bestCount=-1;
+        for(const id in counts){ if(counts[id]>bestCount){bestCount=counts[id];best=id;} }
+        n.data('leafId',best);
+        const vid=videos.find(v=>v.id==best);
+        if(vid) n.data('label', vid.title || String(best));
+      });
+    }
+    function decisionDepth(node){
+      let depth=node.hasClass('decision')?1:0;
+      let cur=node;
+      while(true){
+        const inc=cur.incoming('edge');
+        if(!inc.length) break;
+        cur=inc[0].source();
+        if(cur.hasClass('decision')) depth++;
+      }
+      return depth;
+    }
     function saveState() {
+      refreshLeaves();
       const snap = cy.elements().jsons().map(e => {
         const out = { group: e.group, data: { ...e.data } };
         if (e.group === 'nodes' && e.position) out.position = { ...e.position };
@@ -190,9 +255,12 @@
       });
       const comp = LZString.compressToEncodedURIComponent(JSON.stringify(snap));
       history.replaceState(null, '', '#' + comp);
+      localStorage.setItem('decisionTree', comp);
     }
     function loadState() {
-      const h = location.hash.slice(1); if (!h) return;
+      let h = location.hash.slice(1);
+      if(!h) h = localStorage.getItem('decisionTree') || '';
+      if (!h) return;
       try {
         const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
         cy.elements().remove(); cy.add(arr);
@@ -200,6 +268,7 @@
         const eIds = cy.edges().map(e => +e.id().slice(1)).filter(x=>!isNaN(x));
         nextNodeId = nIds.length ? Math.max(...nIds)+1 : 0;
         nextEdgeId = eIds.length ? Math.max(...eIds)+1 : 0;
+        refreshLeaves();
       } catch(e) {}
     }
     window.addEventListener('popstate', loadState);
@@ -255,31 +324,57 @@
       line.setAttribute('visibility','hidden');
       if (dragging && origin && target && origin.id()!==target.id()) {
         const cnt = cy.edges().filter(e => e.source().id()===origin.id()).length;
-        const lbl = cnt===0 ? 'oui' : cnt===1 ? 'non' : '';
-        cy.add({ group:'edges', data:{ id:'e'+nextEdgeId, source:origin.id(), target:target.id(), label:lbl } });
-        nextEdgeId++; saveState();
+        if(target.hasClass('decision') && decisionDepth(origin) >=3){
+          alert('Profondeur maximale atteinte');
+        } else {
+          const lbl = cnt===0 ? '≤' : cnt===1 ? '>' : '';
+          cy.add({ group:'edges', data:{ id:'e'+nextEdgeId, source:origin.id(), target:target.id(), label:lbl, dir:cnt } });
+          nextEdgeId++; saveState();
+        }
       }
       origin = target = null; dragging = false;
     });
 
-    // Inline editing
+    // Editing
     const labelEditor = document.getElementById('labelEditor'); let editing = null;
+    const nodeModal = document.getElementById('nodeModal');
+    const thresholdInput = document.getElementById('thresholdInput');
+    let editingNode=null;
     function showEditor(ele,pos,text){ editing=ele;
       labelEditor.value = text||'';
       labelEditor.style.left = pos.x + 'px'; labelEditor.style.top = pos.y + 'px';
       labelEditor.style.display = 'block'; labelEditor.focus(); labelEditor.select();
     }
-    cy.on('dbltap','node', evt => showEditor(evt.target, evt.target.renderedPosition(), evt.target.data('label')));
     cy.on('dbltap','edge', evt => {
       const e = evt.target, mid=e.midpoint(), z=cy.zoom(), pan=cy.pan();
       const pos={ x: mid.x*z+pan.x, y: mid.y*z+pan.y };
       showEditor(e,pos,e.data('label'));
     });
+    cy.on('dbltap','node.decision', evt => {
+      editingNode=evt.target;
+      nodeModal.style.display='block';
+      const rect=document.getElementById('cy').getBoundingClientRect();
+      nodeModal.style.left=(rect.left+20)+'px';
+      nodeModal.style.top=(rect.top+20)+'px';
+      if(fieldSelect.options.length) fieldSelect.value=editingNode.data('field')||fieldSelect.options[0].value;
+      thresholdInput.value=editingNode.data('threshold')||0;
+    });
+    cy.on('dbltap','node.leaf', () => { saveState(); });
     labelEditor.addEventListener('keydown', e => { if(e.key==='Enter') commit(); else if(e.key==='Escape') cancel(); });
     labelEditor.addEventListener('blur', commit);
     function commit(){ if(editing && labelEditor.value.trim()){ editing.data('label',labelEditor.value.trim()); saveState(); }
       labelEditor.style.display='none'; editing=null; }
     function cancel(){ labelEditor.style.display='none'; editing=null; }
+    document.getElementById('modalOk').onclick=()=>{
+      if(editingNode){
+        editingNode.data('field', fieldSelect.value);
+        editingNode.data('threshold', Number(thresholdInput.value));
+        editingNode.data('label', `${fieldSelect.value} ≤ ${thresholdInput.value}?`);
+        saveState();
+      }
+      nodeModal.style.display='none'; editingNode=null;
+    };
+    document.getElementById('modalCancel').onclick=()=>{ nodeModal.style.display='none'; editingNode=null; };
 
     // Delete via trash
     let grab=null;


### PR DESCRIPTION
## Summary
- Populate decision-node modal from dataset fields for numeric splits
- Restrict decision depth to three levels
- Store leaf majority video IDs and persist tree to `localStorage`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689650c7ebd083318177ad97ac62401f