### PR TITLE
feat: add recommender module and integrate across pages

### DIFF
--- a/data/videos.json
+++ b/data/videos.json
@@ -1,0 +1,7 @@
+[
+  {"id":1,"title":"Moments drôles du castor bleu","tags":["dessins","humour"],"category":"Dessins","views":1000,"likes":800},
+  {"id":2,"title":"Volcan maison avec vinaigre","tags":["expérience","science"],"category":"Expériences","views":500,"likes":450},
+  {"id":3,"title":"Premiers pas du panda roux","tags":["animaux"],"category":"Animaux","views":800,"likes":700},
+  {"id":4,"title":"Le système solaire expliqué","tags":["science"],"category":"Sciences","views":1200,"likes":1100},
+  {"id":5,"title":"Construction d’un monde en blocs","tags":["jeux vidéo","construction"],"category":"Jeux vidéo","views":1500,"likes":1200}
+]

--- a/index.html
+++ b/index.html
@@ -93,7 +93,9 @@
   <div class="bubble-floating" style="width: 60px; height: 60px; left: 50%; animation-delay: 2s;">👍</div>
   <div class="bubble-floating" style="width: 40px; height: 40px; left: 70%; animation-delay: 7s;">❤️</div>
   <div class="bubble-floating" style="width: 60px; height: 60px; left: 85%; animation-delay: 3s;">👍</div>
-  <script>
+  <script type="module">
+    import * as rec from "./recommender.js";
+    await rec.loadData();
     document.getElementById('start-btn').addEventListener('click', () => {
       document.body.classList.add('fade-out');
       document.body.addEventListener('animationend', () => {

--- a/page1.html
+++ b/page1.html
@@ -128,7 +128,10 @@
   <div class="bubble-floating" style="left: 70%; width:50px; height:50px; animation-delay:7s;"></div>
   <div class="bubble-floating" style="left: 90%; width:80px; height:80px; animation-delay:4s;"></div>
 
-  <script>
+  <script type="module">
+    import * as rec from "./recommender.js";
+    await rec.loadData();
+
     function navigate(url) {
       document.body.classList.add('fade-out');
       const dest = url + location.hash;

--- a/page2.html
+++ b/page2.html
@@ -104,7 +104,10 @@
   <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s;"></div>
   <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s;"></div>
 
-  <script>
+  <script type="module">
+    import * as rec from "./recommender.js";
+    await rec.loadData();
+
     function navigate(url) {
       document.body.classList.add('fade-out');
       const dest = url + location.hash;

--- a/page3.html
+++ b/page3.html
@@ -139,7 +139,10 @@
   <div class="bubble-floating" style="left:70%; width:50px; height:50px; animation-delay:7s;"></div>
   <div class="bubble-floating" style="left:90%; width:80px; height:80px; animation-delay:4s;"></div>
 
-  <script>
+  <script type="module">
+    import * as rec from "./recommender.js";
+    await rec.loadData();
+
     function navigate(url) {
       saveState();
       document.body.classList.add('fade-out');

--- a/page4.html
+++ b/page4.html
@@ -41,7 +41,10 @@ th{background:rgba(255,255,255,.2)}
     <div id="results"></div>
   </div>
 </div>
-<script>
+<script type="module">
+import * as rec from "./recommender.js";
+const videos = await rec.loadData();
+
 function navigate(u){
  document.body.classList.add('fade-out');
  const dest=u+location.hash;
@@ -113,9 +116,10 @@ function vecFromTitle(t){const v=new Uint8Array(vocab.length);for(const w of tok
 function cosine(a,b,nB){let dot=0,nA=0;for(let i=0;i<a.length;i++){if(a[i]){nA++;if(b[i])dot++}}if(nA===0||nB===0)return 0;return dot/Math.sqrt(nA*nB)}
 function trainModel(){buildVocab();const sums={},counts={};for(const r of trainData){const v=vecFromTitle(r.title);const lab=r.label;if(!sums[lab]){sums[lab]=new Float32Array(vocab.length);counts[lab]=0}for(let i=0;i<v.length;i++){sums[lab][i]+=v[i]}counts[lab]++}for(const lab in sums){for(let i=0;i<vocab.length;i++){sums[lab][i]/=counts[lab]}centroids[lab]=sums[lab];let n=0;for(let i=0;i<vocab.length;i++){if(centroids[lab][i]>0)n++}centroidNorm[lab]=Math.sqrt(n)}return counts}
 function predict(t){const v=vecFromTitle(t);let best=null,bestScore=-1;for(const lab in centroids){const s=cosine(v,centroids[lab],centroidNorm[lab]);if(s>bestScore){bestScore=s;best=lab}}return best}
-document.getElementById('trainBtn').addEventListener('click',()=>{
+document.getElementById('trainBtn').addEventListener('click',async()=>{
  document.getElementById('trainBtn').disabled=true
  document.getElementById('status').textContent='Entraînement...'
+ await rec.train(videos);
  setTimeout(()=>{
   trainModel()
   document.getElementById('status').textContent='Génération des recommandations...'

--- a/page5.html
+++ b/page5.html
@@ -141,7 +141,13 @@
   <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s"></div>
   <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s"></div>
 
-  <script>
+  <script type="module">
+    import * as rec from "./recommender.js";
+    const videos = await rec.loadData();
+    if(!localStorage.getItem('trainedModel')) {
+      rec.train(videos);
+    }
+
     function navigate(url) {
       document.body.classList.add('fade-out');
       const dest = url + location.hash;
@@ -188,76 +194,15 @@
     }
     loadTree();
 
-    // --- Données d'entraînement et modèle ---
-    function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
-    const trainData=[
-      {title:'Moments drôles du castor bleu',label:'Dessins'},
-      {title:'La course folle du lapin malin',label:'Dessins'},
-      {title:'La flaque de boue magique',label:'Dessins'},
-      {title:'Le coureur et le coyote rigolo',label:'Dessins'},
-      {title:'Aventure au chalet des amis',label:'Dessins'},
-      {title:'Blagues du duo farceur',label:'Dessins'},
-      {title:'Sauvetage dans la forêt mystique',label:'Dessins'},
-      {title:'Patrouille du port joyeux',label:'Dessins'},
-      {title:'Fête de danse des chiots',label:'Dessins'},
-      {title:'La montagne russe bricolée',label:'Dessins'},
-      {title:'Volcan maison avec vinaigre',label:'Expériences'},
-      {title:'Fusée au bicarbonate de soude',label:'Expériences'},
-      {title:'Réaction pâte à dents géante',label:'Expériences'},
-      {title:'Fabriquer du slime étirable',label:'Expériences'},
-      {title:'Lait qui change de couleur',label:'Expriences'},
-      {title:'Oobleck étrange liquide‑solide',label:'Expériences'},
-      {title:'Voiture ballon propulsée',label:'Expériences'},
-      {title:'Lampe lave DIY',label:'Expériences'},
-      {title:'Pile citron maison',label:'Expériences'},
-      {title:'Fontaine menthe et cola',label:'Expériences'},
-      {title:'Premiers pas du panda roux',label:'Animaux'},
-      {title:'Safari rugissements du lion',label:'Animaux'},
-      {title:'Chiens exécutent des tours',label:'Animaux'},
-      {title:'Chatons jouent au laser',label:'Animaux'},
-      {title:'Sauts spectaculaires des dauphins',label:'Animaux'},
-      {title:'Danse des oiseaux tropicaux',label:'Animaux'},
-      {title:'Vie secrète des fourmis',label:'Animaux'},
-      {title:'Sauvetage d’un manchot',label:'Animaux'},
-      {title:'Bain de boue de l’éléphant',label:'Animaux'},
-      {title:'Grimpe du panda roux',label:'Animaux'},
-      {title:'Le système solaire expliqué',label:'Sciences'},
-      {title:'Pourquoi les plantes sont vertes',label:'Sciences'},
-      {title:'Physique des montagnes russes',label:'Sciences'},
-      {title:'Voyage dans le corps humain',label:'Sciences'},
-      {title:'Construire un circuit simple',label:'Sciences'},
-      {title:'Cycle de l’eau illustré',label:'Sciences'},
-      {title:'Bases du magnétisme',label:'Sciences'},
-      {title:'Les états de la matière',label:'Sciences'},
-      {title:'Documentaire sur les dinosaures',label:'Sciences'},
-      {title:'Introduction à l’électricité',label:'Sciences'},
-      {title:'Guide débutant de l’île pixel',label:'Jeux vidéo'},
-      {title:'Course folle de kart arctique',label:'Jeux vidéo'},
-      {title:'Construction d’un monde en blocs',label:'Jeux vidéo'},
-      {title:'Défi danse rythmique arcade',label:'Jeux vidéo'},
-      {title:'Stratégie conquête médiévale',label:'Jeux vidéo'},
-      {title:'Aventure RPG forêt enchantée',label:'Jeux vidéo'},
-      {title:'Match de soccer virtuel',label:'Jeux vidéo'},
-      {title:'Puzzle plateforme spatiale',label:'Jeux vidéo'},
-      {title:'Course à obstacles néon',label:'Jeux vidéo'},
-      {title:'Simulation ferme canadienne',label:'Jeux vidéo'}
-    ];
     const testData=[
       {title:'Bataille de robots rétro',label:'Jeux vidéo'},
       {title:'Expérience œuf rebondissant',label:'Expériences'},
       {title:'Pourquoi avons‑nous des saisons',label:'Sciences'},
       {title:'Premiers pas du koala',label:'Animaux'}
     ];
-    const recVid={Dessins:'Aventure au chalet des amis',Expériences:'Réaction pâte à dents géante',Animaux:'Premiers pas du panda roux',Sciences:'Le système solaire expliqué','Jeux vidéo':'Construction d’un monde en blocs'};
-    let vocab=[],word2idx={},centroids={},centroidNorm={};
-    function buildVocab(){for(const r of trainData){for(const w of tokens(r.title)){if(word2idx[w]===undefined){word2idx[w]=vocab.length;vocab.push(w)}}}}
-    function vecFromTitle(t){const v=new Uint8Array(vocab.length);for(const w of tokens(t)){const i=word2idx[w];if(i!==undefined)v[i]=1}return v}
-    function cosine(a,b,nB){let dot=0,nA=0;for(let i=0;i<a.length;i++){if(a[i]){nA++;if(b[i])dot++}}if(nA===0||nB===0)return 0;return dot/Math.sqrt(nA*nB)}
-    function trainModel(){buildVocab();const sums={},counts={};for(const r of trainData){const v=vecFromTitle(r.title);const lab=r.label;if(!sums[lab]){sums[lab]=new Float32Array(vocab.length);counts[lab]=0}for(let i=0;i<v.length;i++){sums[lab][i]+=v[i]}counts[lab]++}for(const lab in sums){for(let i=0;i<vocab.length;i++){sums[lab][i]/=counts[lab]}centroids[lab]=sums[lab];let n=0;for(let i=0;i<vocab.length;i++){if(centroids[lab][i]>0)n++}centroidNorm[lab]=Math.sqrt(n)}}
-    function predict(t){const v=vecFromTitle(t);let best=null,bestScore=-1;for(const lab in centroids){const s=cosine(v,centroids[lab],centroidNorm[lab]);if(s>bestScore){bestScore=s;best=lab}}return best}
-
+    const choices=['Dessins','Expériences','Animaux','Sciences','Jeux vidéo'];
     let modelCorrect=0,userCorrect=0,currentTest=0;
-    trainModel();
+
     function showTest(){
       if(currentTest>=testData.length){
         document.getElementById('current-title').textContent='Fin des tests';
@@ -267,11 +212,16 @@
       }
       const t=testData[currentTest];
       document.getElementById('current-title').textContent=`Visionné : ${t.title}`;
-      const cat=predict(t.title);
-      const suggestion=recVid[cat]||'Aucune';
+      const id = rec.rank(t.title, 0.5, 1)[0];
+      const vid = videos.find(v=>v.id===id);
+      const suggestion = vid ? vid.title : 'Aucune';
       document.getElementById('model-pred').innerHTML=`Suggestion : <strong>${suggestion}</strong>`;
-      if(cat===t.label){modelCorrect++;document.getElementById('model-correct').textContent=modelCorrect;}
+      if(vid && vid.category===t.label){modelCorrect++;document.getElementById('model-correct').textContent=modelCorrect;}
+      const choiceDiv=document.querySelector('.choices');
+      choiceDiv.innerHTML='';
+      choices.forEach(cat=>{const b=document.createElement('button');b.textContent=cat;b.onclick=()=>vote(cat);choiceDiv.appendChild(b);});
     }
+
     function vote(cat){
       if(currentTest>=testData.length)return;
       const t=testData[currentTest];

--- a/recommender.js
+++ b/recommender.js
@@ -1,0 +1,1 @@
+export * from './src/recommender.js';

--- a/src/recommender.js
+++ b/src/recommender.js
@@ -1,0 +1,132 @@
+const DATA_URL = '/data/videos.json';
+const DATA_KEY = 'videosCache';
+const MODEL_KEY = 'trainedModel';
+const SETTINGS_KEY = 'recSettings';
+
+const ls = typeof localStorage === 'undefined' ? {
+  _data:{},
+  getItem(k){ return this._data[k] ?? null; },
+  setItem(k,v){ this._data[k] = String(v); },
+  removeItem(k){ delete this._data[k]; }
+} : localStorage;
+
+let dataCache = null;
+let vocab = [];
+let idf = {};
+let vectors = [];
+let model = JSON.parse(ls.getItem(MODEL_KEY) || 'null');
+let settings = JSON.parse(ls.getItem(SETTINGS_KEY) || '{}');
+
+function tokenize(text){
+  return text
+    .toLowerCase()
+    .normalize('NFD').replace(/[\u0300-\u036f]/g,'')
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+export async function loadData(){
+  if(dataCache) return dataCache;
+  const cached = ls.getItem(DATA_KEY);
+  if(cached){
+    dataCache = JSON.parse(cached);
+    return dataCache;
+  }
+  const resp = await fetch(DATA_URL);
+  dataCache = await resp.json();
+  ls.setItem(DATA_KEY, JSON.stringify(dataCache));
+  return dataCache;
+}
+
+export function buildVocab(videos){
+  const df = {};
+  vectors = [];
+  videos.forEach(v => {
+    const tokens = tokenize(v.title + ' ' + (v.tags||[]).join(' '));
+    const tf = {};
+    tokens.forEach(t => { tf[t] = (tf[t]||0) + 1; });
+    vectors.push({ id:v.id, category:v.category, views:v.views||0, likes:v.likes||0, tf });
+    Object.keys(tf).forEach(t => { df[t] = (df[t]||0) + 1; });
+  });
+  vocab = Object.keys(df);
+  const N = videos.length;
+  idf = {};
+  vocab.forEach(term => { idf[term] = Math.log(N/df[term]); });
+  vectors = vectors.map(doc => {
+    const vec = {};
+    let norm = 0;
+    Object.entries(doc.tf).forEach(([term,freq]) => {
+      const weight = freq * idf[term];
+      vec[term] = weight;
+      norm += weight * weight;
+    });
+    return { ...doc, vec, norm: Math.sqrt(norm) };
+  });
+  return { vocab, idf, vectors };
+}
+
+export function train(cleanVideos){
+  const built = buildVocab(cleanVideos);
+  const classStats = {};
+  const viewLogs = cleanVideos.map(v => Math.log10((v.views||1)));
+  const gMean = viewLogs.reduce((a,b)=>a+b,0)/viewLogs.length;
+  const gStd = Math.sqrt(viewLogs.reduce((a,b)=>a+(b-gMean)**2,0)/viewLogs.length);
+
+  built.vectors.forEach(doc => {
+    const lab = doc.category;
+    if(!classStats[lab]) classStats[lab] = {count:0, centroid:{}, likePct:0, views:[]};
+    const cs = classStats[lab];
+    cs.count++;
+    cs.likePct += (doc.likes||0)/(doc.views||1);
+    cs.views.push(Math.log10(doc.views||1));
+    Object.entries(doc.vec).forEach(([term,val]) => {
+      cs.centroid[term] = (cs.centroid[term]||0) + val;
+    });
+  });
+
+  const classes = {};
+  Object.entries(classStats).forEach(([lab,cs]) => {
+    const centroid = {};
+    Object.entries(cs.centroid).forEach(([term,val]) => {
+      centroid[term] = val / cs.count;
+    });
+    const norm = Math.sqrt(Object.values(centroid).reduce((s,v)=>s+v*v,0)) || 1;
+    const vMean = cs.views.reduce((a,b)=>a+b,0)/cs.views.length;
+    const vStd = Math.sqrt(cs.views.reduce((a,b)=>a+(b-vMean)**2,0)/cs.views.length);
+    classes[lab] = { centroid, norm, likePct: cs.likePct / cs.count, views:{mean:vMean,std:vStd} };
+  });
+
+  model = { vocab: built.vocab, idf: built.idf, classes, globalViews:{mean:gMean,std:gStd} };
+  ls.setItem(MODEL_KEY, JSON.stringify(model));
+  return model;
+}
+
+export function rank(title, lambdaPop=0.5, k=3){
+  if(!model){
+    const stored = ls.getItem(MODEL_KEY);
+    if(stored) model = JSON.parse(stored); else return [];
+  }
+  if(settings.lambda === undefined) settings.lambda = lambdaPop;
+  lambdaPop = settings.lambda;
+  ls.setItem(SETTINGS_KEY, JSON.stringify(settings));
+
+  const tokens = tokenize(title);
+  const tf = {};
+  tokens.forEach(t => { if(model.idf[t]) tf[t] = (tf[t]||0) + 1; });
+  let vec = {}, norm = 0;
+  Object.entries(tf).forEach(([term,freq]) => {
+    const w = freq * model.idf[term];
+    vec[term] = w; norm += w*w;
+  });
+  norm = Math.sqrt(norm) || 1;
+
+  const scores = vectors.map(doc => {
+    let dot = 0;
+    Object.keys(vec).forEach(term => { if(doc.vec[term]) dot += doc.vec[term]*vec[term]; });
+    const cos = doc.norm ? dot/(doc.norm*norm) : 0;
+    const pop = Math.log10(doc.views||1);
+    return { id: doc.id, score: cos * (1 + lambdaPop * pop) };
+  });
+
+  return scores.sort((a,b)=>b.score-a.score).slice(0,k).map(s=>s.id);
+}


### PR DESCRIPTION
## Summary
- add TF‑IDF recommender module with data loading, training, and ranking helpers
- persist model/settings via localStorage and cache dataset
- import recommender on all pages and hook into training and ranking flows

## Testing
- `node -e "import('./src/recommender.js').then(m=>console.log('functions',Object.keys(m)))"`
- `node -e "import('./src/recommender.js').then(async m=>{const data=await m.loadData(); console.log('len',data.length)})"` *(fails: Failed to parse URL from /data/videos.json)*

------
https://chatgpt.com/codex/tasks/task_e_689650c62b188331a01ac5db713c3352