### PR TITLE
Load video dataset from JSON

### DIFF
--- a/page4.html
+++ b/page4.html
@@ -41,92 +41,42 @@ th{background:rgba(255,255,255,.2)}
     <div id="results"></div>
   </div>
 </div>
-<script>
+<script type="module">
+import { loadData } from './recommender.js';
+
 function navigate(u){
  document.body.classList.add('fade-out');
  const dest=u+location.hash;
- document.body.addEventListener('animationend',()=>location.href=dest,{once:true})
+ document.body.addEventListener('animationend',()=>location.href=dest,{once:true});
 }
+window.navigate = navigate;
 function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
-const trainData=[
-{title:'Moments drôles du castor bleu',label:'Dessins'},
-{title:'La course folle du lapin malin',label:'Dessins'},
-{title:'La flaque de boue magique',label:'Dessins'},
-{title:'Le coureur et le coyote rigolo',label:'Dessins'},
-{title:'Aventure au chalet des amis',label:'Dessins'},
-{title:'Blagues du duo farceur',label:'Dessins'},
-{title:'Sauvetage dans la forêt mystique',label:'Dessins'},
-{title:'Patrouille du port joyeux',label:'Dessins'},
-{title:'Fête de danse des chiots',label:'Dessins'},
-{title:'La montagne russe bricolée',label:'Dessins'},
-{title:'Volcan maison avec vinaigre',label:'Expériences'},
-{title:'Fusée au bicarbonate de soude',label:'Expériences'},
-{title:'Réaction pâte à dents géante',label:'Expériences'},
-{title:'Fabriquer du slime étirable',label:'Expériences'},
-{title:'Lait qui change de couleur',label:'Expériences'},
-{title:'Oobleck étrange liquide‑solide',label:'Expériences'},
-{title:'Voiture ballon propulsée',label:'Expériences'},
-{title:'Lampe lave DIY',label:'Expériences'},
-{title:'Pile citron maison',label:'Expériences'},
-{title:'Fontaine menthe et cola',label:'Expériences'},
-{title:'Premiers pas du panda roux',label:'Animaux'},
-{title:'Safari rugissements du lion',label:'Animaux'},
-{title:'Chiens exécutent des tours',label:'Animaux'},
-{title:'Chatons jouent au laser',label:'Animaux'},
-{title:'Sauts spectaculaires des dauphins',label:'Animaux'},
-{title:'Danse des oiseaux tropicaux',label:'Animaux'},
-{title:'Vie secrète des fourmis',label:'Animaux'},
-{title:'Sauvetage d’un manchot',label:'Animaux'},
-{title:'Bain de boue de l’éléphant',label:'Animaux'},
-{title:'Grimpe du panda roux',label:'Animaux'},
-{title:'Le système solaire expliqué',label:'Sciences'},
-{title:'Pourquoi les plantes sont vertes',label:'Sciences'},
-{title:'Physique des montagnes russes',label:'Sciences'},
-{title:'Voyage dans le corps humain',label:'Sciences'},
-{title:'Construire un circuit simple',label:'Sciences'},
-{title:'Cycle de l’eau illustré',label:'Sciences'},
-{title:'Bases du magnétisme',label:'Sciences'},
-{title:'Les états de la matière',label:'Sciences'},
-{title:'Documentaire sur les dinosaures',label:'Sciences'},
-{title:'Introduction à l’électricité',label:'Sciences'},
-{title:'Guide débutant de l’île pixel',label:'Jeux vidéo'},
-{title:'Course folle de kart arctique',label:'Jeux vidéo'},
-{title:'Construction d’un monde en blocs',label:'Jeux vidéo'},
-{title:'Défi danse rythmique arcade',label:'Jeux vidéo'},
-{title:'Stratégie conquête médiévale',label:'Jeux vidéo'},
-{title:'Aventure RPG forêt enchantée',label:'Jeux vidéo'},
-{title:'Match de soccer virtuel',label:'Jeux vidéo'},
-{title:'Puzzle plateforme spatiale',label:'Jeux vidéo'},
-{title:'Course à obstacles néon',label:'Jeux vidéo'},
-{title:'Simulation ferme canadienne',label:'Jeux vidéo'}
-]
-const testData=[
-{title:'Bataille de robots rétro',label:'Jeux vidéo'},
-{title:'Expérience œuf rebondissant',label:'Expériences'},
-{title:'Pourquoi avons‑nous des saisons',label:'Sciences'},
-{title:'Premiers pas du koala',label:'Animaux'}
-]
-const recVid={Dessins:'Aventure au chalet des amis',Expériences:'Réaction pâte à dents géante',Animaux:'Premiers pas du panda roux',Sciences:'Le système solaire expliqué','Jeux vidéo':'Construction d’un monde en blocs'}
-let vocab=[],word2idx={},centroids={},centroidNorm={}
+
+let trainData=[],testData=[],recVid={};
+let vocab=[],word2idx={},centroids={},centroidNorm={};
 function buildVocab(){for(const r of trainData){for(const w of tokens(r.title)){if(word2idx[w]===undefined){word2idx[w]=vocab.length;vocab.push(w)}}}}
 function vecFromTitle(t){const v=new Uint8Array(vocab.length);for(const w of tokens(t)){const i=word2idx[w];if(i!==undefined)v[i]=1}return v}
 function cosine(a,b,nB){let dot=0,nA=0;for(let i=0;i<a.length;i++){if(a[i]){nA++;if(b[i])dot++}}if(nA===0||nB===0)return 0;return dot/Math.sqrt(nA*nB)}
 function trainModel(){buildVocab();const sums={},counts={};for(const r of trainData){const v=vecFromTitle(r.title);const lab=r.label;if(!sums[lab]){sums[lab]=new Float32Array(vocab.length);counts[lab]=0}for(let i=0;i<v.length;i++){sums[lab][i]+=v[i]}counts[lab]++}for(const lab in sums){for(let i=0;i<vocab.length;i++){sums[lab][i]/=counts[lab]}centroids[lab]=sums[lab];let n=0;for(let i=0;i<vocab.length;i++){if(centroids[lab][i]>0)n++}centroidNorm[lab]=Math.sqrt(n)}return counts}
 function predict(t){const v=vecFromTitle(t);let best=null,bestScore=-1;for(const lab in centroids){const s=cosine(v,centroids[lab],centroidNorm[lab]);if(s>bestScore){bestScore=s;best=lab}}return best}
-document.getElementById('trainBtn').addEventListener('click',()=>{
- document.getElementById('trainBtn').disabled=true
- document.getElementById('status').textContent='Entraînement...'
- setTimeout(()=>{
-  trainModel()
-  document.getElementById('status').textContent='Génération des recommandations...'
-  let res='<h3>Suggestions après test</h3><table><tr><th>Titre visionné</th><th>Vidéo suggérée</th><th></th></tr>'
-  for(const r of testData){const cat=predict(r.title);const ok=cat===r.label?'✅':'❌';res+=`<tr><td>${r.title}</td><td>${recVid[cat]||'Aucune'}</td><td>${ok}</td></tr>`}
-  res+='</table>'
-  document.getElementById('results').innerHTML=res
-  document.getElementById('status').textContent='Terminé'
-  document.getElementById('trainBtn').disabled=false
- },800)
-})
+
+loadData().then(data=>{
+  ({trainData,testData,recVid}=data);
+  document.getElementById('trainBtn').addEventListener('click',()=>{
+   document.getElementById('trainBtn').disabled=true;
+   document.getElementById('status').textContent='Entraînement...';
+   setTimeout(()=>{
+    trainModel();
+    document.getElementById('status').textContent='Génération des recommandations...';
+    let res='<h3>Suggestions après test</h3><table><tr><th>Titre visionné</th><th>Vidéo suggérée</th><th></th></tr>';
+    for(const r of testData){const cat=predict(r.title);const ok=cat===r.label?'✅':'❌';res+=`<tr><td>${r.title}</td><td>${recVid[cat]||'Aucune'}</td><td>${ok}</td></tr>`}
+    res+='</table>';
+    document.getElementById('results').innerHTML=res;
+    document.getElementById('status').textContent='Terminé';
+    document.getElementById('trainBtn').disabled=false;
+   },800);
+  });
+});
 </script>
 </body>
 </html>

--- a/page5.html
+++ b/page5.html
@@ -141,14 +141,14 @@
   <div class="bubble-floating" style="left:70%;width:50px;height:50px;animation-delay:7s"></div>
   <div class="bubble-floating" style="left:90%;width:80px;height:80px;animation-delay:4s"></div>
 
-  <script>
+  <script type="module">
+    import { loadData } from './recommender.js';
     function navigate(url) {
       document.body.classList.add('fade-out');
       const dest = url + location.hash;
       document.body.addEventListener('animationend', () => window.location.href = dest, { once: true });
     }
-
-    // Load decision tree from URL
+      window.navigate = navigate;
     const cy = cytoscape({
       container: document.getElementById('cy'),
       elements: [],
@@ -188,67 +188,8 @@
     }
     loadTree();
 
-    // --- Données d'entraînement et modèle ---
     function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
-    const trainData=[
-      {title:'Moments drôles du castor bleu',label:'Dessins'},
-      {title:'La course folle du lapin malin',label:'Dessins'},
-      {title:'La flaque de boue magique',label:'Dessins'},
-      {title:'Le coureur et le coyote rigolo',label:'Dessins'},
-      {title:'Aventure au chalet des amis',label:'Dessins'},
-      {title:'Blagues du duo farceur',label:'Dessins'},
-      {title:'Sauvetage dans la forêt mystique',label:'Dessins'},
-      {title:'Patrouille du port joyeux',label:'Dessins'},
-      {title:'Fête de danse des chiots',label:'Dessins'},
-      {title:'La montagne russe bricolée',label:'Dessins'},
-      {title:'Volcan maison avec vinaigre',label:'Expériences'},
-      {title:'Fusée au bicarbonate de soude',label:'Expériences'},
-      {title:'Réaction pâte à dents géante',label:'Expériences'},
-      {title:'Fabriquer du slime étirable',label:'Expériences'},
-      {title:'Lait qui change de couleur',label:'Expriences'},
-      {title:'Oobleck étrange liquide‑solide',label:'Expériences'},
-      {title:'Voiture ballon propulsée',label:'Expériences'},
-      {title:'Lampe lave DIY',label:'Expériences'},
-      {title:'Pile citron maison',label:'Expériences'},
-      {title:'Fontaine menthe et cola',label:'Expériences'},
-      {title:'Premiers pas du panda roux',label:'Animaux'},
-      {title:'Safari rugissements du lion',label:'Animaux'},
-      {title:'Chiens exécutent des tours',label:'Animaux'},
-      {title:'Chatons jouent au laser',label:'Animaux'},
-      {title:'Sauts spectaculaires des dauphins',label:'Animaux'},
-      {title:'Danse des oiseaux tropicaux',label:'Animaux'},
-      {title:'Vie secrète des fourmis',label:'Animaux'},
-      {title:'Sauvetage d’un manchot',label:'Animaux'},
-      {title:'Bain de boue de l’éléphant',label:'Animaux'},
-      {title:'Grimpe du panda roux',label:'Animaux'},
-      {title:'Le système solaire expliqué',label:'Sciences'},
-      {title:'Pourquoi les plantes sont vertes',label:'Sciences'},
-      {title:'Physique des montagnes russes',label:'Sciences'},
-      {title:'Voyage dans le corps humain',label:'Sciences'},
-      {title:'Construire un circuit simple',label:'Sciences'},
-      {title:'Cycle de l’eau illustré',label:'Sciences'},
-      {title:'Bases du magnétisme',label:'Sciences'},
-      {title:'Les états de la matière',label:'Sciences'},
-      {title:'Documentaire sur les dinosaures',label:'Sciences'},
-      {title:'Introduction à l’électricité',label:'Sciences'},
-      {title:'Guide débutant de l’île pixel',label:'Jeux vidéo'},
-      {title:'Course folle de kart arctique',label:'Jeux vidéo'},
-      {title:'Construction d’un monde en blocs',label:'Jeux vidéo'},
-      {title:'Défi danse rythmique arcade',label:'Jeux vidéo'},
-      {title:'Stratégie conquête médiévale',label:'Jeux vidéo'},
-      {title:'Aventure RPG forêt enchantée',label:'Jeux vidéo'},
-      {title:'Match de soccer virtuel',label:'Jeux vidéo'},
-      {title:'Puzzle plateforme spatiale',label:'Jeux vidéo'},
-      {title:'Course à obstacles néon',label:'Jeux vidéo'},
-      {title:'Simulation ferme canadienne',label:'Jeux vidéo'}
-    ];
-    const testData=[
-      {title:'Bataille de robots rétro',label:'Jeux vidéo'},
-      {title:'Expérience œuf rebondissant',label:'Expériences'},
-      {title:'Pourquoi avons‑nous des saisons',label:'Sciences'},
-      {title:'Premiers pas du koala',label:'Animaux'}
-    ];
-    const recVid={Dessins:'Aventure au chalet des amis',Expériences:'Réaction pâte à dents géante',Animaux:'Premiers pas du panda roux',Sciences:'Le système solaire expliqué','Jeux vidéo':'Construction d’un monde en blocs'};
+    let trainData=[],testData=[],recVid={};
     let vocab=[],word2idx={},centroids={},centroidNorm={};
     function buildVocab(){for(const r of trainData){for(const w of tokens(r.title)){if(word2idx[w]===undefined){word2idx[w]=vocab.length;vocab.push(w)}}}}
     function vecFromTitle(t){const v=new Uint8Array(vocab.length);for(const w of tokens(t)){const i=word2idx[w];if(i!==undefined)v[i]=1}return v}
@@ -257,7 +198,6 @@
     function predict(t){const v=vecFromTitle(t);let best=null,bestScore=-1;for(const lab in centroids){const s=cosine(v,centroids[lab],centroidNorm[lab]);if(s>bestScore){bestScore=s;best=lab}}return best}
 
     let modelCorrect=0,userCorrect=0,currentTest=0;
-    trainModel();
     function showTest(){
       if(currentTest>=testData.length){
         document.getElementById('current-title').textContent='Fin des tests';
@@ -279,7 +219,13 @@
       currentTest++;
       showTest();
     }
-    showTest();
+      window.vote = vote;
+
+    loadData().then(data=>{
+      ({trainData,testData,recVid}=data);
+      trainModel();
+      showTest();
+    });
   </script>
 </body>
 </html>

--- a/public/data/videos.json
+++ b/public/data/videos.json
@@ -1,0 +1,817 @@
+[
+  {
+    "id": 1,
+    "title": "Moments drôles du castor bleu",
+    "category": "Dessins",
+    "views": 440172,
+    "likes": 123,
+    "dislikes": 212,
+    "comments": 3469,
+    "publishedDaysAgo": 197,
+    "lenSec": 1024,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 2,
+    "title": "La course folle du lapin malin",
+    "category": "Dessins",
+    "views": 39518,
+    "likes": 31080,
+    "dislikes": 448,
+    "comments": 1085,
+    "publishedDaysAgo": 80,
+    "lenSec": 472,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 3,
+    "title": "La flaque de boue magique",
+    "category": "Dessins",
+    "views": 559256,
+    "likes": 42591,
+    "dislikes": 395,
+    "comments": 2474,
+    "publishedDaysAgo": 157,
+    "lenSec": 1026,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 4,
+    "title": "Le coureur et le coyote rigolo",
+    "category": "Dessins",
+    "views": 915336,
+    "likes": 20269,
+    "dislikes": 422,
+    "comments": 3677,
+    "publishedDaysAgo": 313,
+    "lenSec": 1658,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 5,
+    "title": "Aventure au chalet des amis",
+    "category": "Dessins",
+    "views": 850955,
+    "likes": 2547,
+    "dislikes": 111,
+    "comments": 879,
+    "publishedDaysAgo": 670,
+    "lenSec": 798,
+    "tags": [
+      "Dessins",
+      "train",
+      "rec"
+    ]
+  },
+  {
+    "id": 6,
+    "title": "Blagues du duo farceur",
+    "category": "Dessins",
+    "views": 596692,
+    "likes": 24473,
+    "dislikes": 114,
+    "comments": 4883,
+    "publishedDaysAgo": 830,
+    "lenSec": 644,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 7,
+    "title": "Sauvetage dans la forêt mystique",
+    "category": "Dessins",
+    "views": 944640,
+    "likes": 43309,
+    "dislikes": 160,
+    "comments": 1437,
+    "publishedDaysAgo": 238,
+    "lenSec": 837,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 8,
+    "title": "Patrouille du port joyeux",
+    "category": "Dessins",
+    "views": 419550,
+    "likes": 27954,
+    "dislikes": 301,
+    "comments": 4500,
+    "publishedDaysAgo": 283,
+    "lenSec": 376,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 9,
+    "title": "Fête de danse des chiots",
+    "category": "Dessins",
+    "views": 174999,
+    "likes": 3420,
+    "dislikes": 26,
+    "comments": 2706,
+    "publishedDaysAgo": 579,
+    "lenSec": 911,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 10,
+    "title": "La montagne russe bricolée",
+    "category": "Dessins",
+    "views": 880226,
+    "likes": 2186,
+    "dislikes": 114,
+    "comments": 4446,
+    "publishedDaysAgo": 60,
+    "lenSec": 803,
+    "tags": [
+      "Dessins",
+      "train"
+    ]
+  },
+  {
+    "id": 11,
+    "title": "Volcan maison avec vinaigre",
+    "category": "Expériences",
+    "views": 376187,
+    "likes": 34575,
+    "dislikes": 77,
+    "comments": 3016,
+    "publishedDaysAgo": 98,
+    "lenSec": 686,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 12,
+    "title": "Fusée au bicarbonate de soude",
+    "category": "Expériences",
+    "views": 607155,
+    "likes": 37444,
+    "dislikes": 398,
+    "comments": 4361,
+    "publishedDaysAgo": 896,
+    "lenSec": 958,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 13,
+    "title": "Réaction pâte à dents géante",
+    "category": "Expériences",
+    "views": 989559,
+    "likes": 49542,
+    "dislikes": 3,
+    "comments": 3431,
+    "publishedDaysAgo": 89,
+    "lenSec": 688,
+    "tags": [
+      "Expériences",
+      "train",
+      "rec"
+    ]
+  },
+  {
+    "id": 14,
+    "title": "Fabriquer du slime étirable",
+    "category": "Expériences",
+    "views": 625089,
+    "likes": 27905,
+    "dislikes": 48,
+    "comments": 526,
+    "publishedDaysAgo": 658,
+    "lenSec": 446,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 15,
+    "title": "Lait qui change de couleur",
+    "category": "Expériences",
+    "views": 330112,
+    "likes": 25941,
+    "dislikes": 473,
+    "comments": 4075,
+    "publishedDaysAgo": 973,
+    "lenSec": 984,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 16,
+    "title": "Oobleck étrange liquide‑solide",
+    "category": "Expériences",
+    "views": 68436,
+    "likes": 24809,
+    "dislikes": 405,
+    "comments": 3674,
+    "publishedDaysAgo": 692,
+    "lenSec": 1718,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 17,
+    "title": "Voiture ballon propulsée",
+    "category": "Expériences",
+    "views": 53946,
+    "likes": 31713,
+    "dislikes": 389,
+    "comments": 2117,
+    "publishedDaysAgo": 356,
+    "lenSec": 1710,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 18,
+    "title": "Lampe lave DIY",
+    "category": "Expériences",
+    "views": 398911,
+    "likes": 21200,
+    "dislikes": 106,
+    "comments": 621,
+    "publishedDaysAgo": 963,
+    "lenSec": 1668,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 19,
+    "title": "Pile citron maison",
+    "category": "Expériences",
+    "views": 400553,
+    "likes": 17256,
+    "dislikes": 451,
+    "comments": 1052,
+    "publishedDaysAgo": 378,
+    "lenSec": 816,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 20,
+    "title": "Fontaine menthe et cola",
+    "category": "Expériences",
+    "views": 478487,
+    "likes": 6199,
+    "dislikes": 378,
+    "comments": 3905,
+    "publishedDaysAgo": 401,
+    "lenSec": 1197,
+    "tags": [
+      "Expériences",
+      "train"
+    ]
+  },
+  {
+    "id": 21,
+    "title": "Premiers pas du panda roux",
+    "category": "Animaux",
+    "views": 757439,
+    "likes": 20083,
+    "dislikes": 199,
+    "comments": 4617,
+    "publishedDaysAgo": 692,
+    "lenSec": 1386,
+    "tags": [
+      "Animaux",
+      "train",
+      "rec"
+    ]
+  },
+  {
+    "id": 22,
+    "title": "Safari rugissements du lion",
+    "category": "Animaux",
+    "views": 605832,
+    "likes": 27625,
+    "dislikes": 265,
+    "comments": 3012,
+    "publishedDaysAgo": 425,
+    "lenSec": 1794,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 23,
+    "title": "Chiens exécutent des tours",
+    "category": "Animaux",
+    "views": 559047,
+    "likes": 15206,
+    "dislikes": 316,
+    "comments": 4811,
+    "publishedDaysAgo": 145,
+    "lenSec": 622,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 24,
+    "title": "Chatons jouent au laser",
+    "category": "Animaux",
+    "views": 2995,
+    "likes": 2590,
+    "dislikes": 80,
+    "comments": 2299,
+    "publishedDaysAgo": 789,
+    "lenSec": 1317,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 25,
+    "title": "Sauts spectaculaires des dauphins",
+    "category": "Animaux",
+    "views": 459934,
+    "likes": 34865,
+    "dislikes": 91,
+    "comments": 3775,
+    "publishedDaysAgo": 68,
+    "lenSec": 1576,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 26,
+    "title": "Danse des oiseaux tropicaux",
+    "category": "Animaux",
+    "views": 600718,
+    "likes": 30249,
+    "dislikes": 488,
+    "comments": 2184,
+    "publishedDaysAgo": 221,
+    "lenSec": 847,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 27,
+    "title": "Vie secrète des fourmis",
+    "category": "Animaux",
+    "views": 428613,
+    "likes": 41305,
+    "dislikes": 158,
+    "comments": 1449,
+    "publishedDaysAgo": 106,
+    "lenSec": 971,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 28,
+    "title": "Sauvetage d’un manchot",
+    "category": "Animaux",
+    "views": 350330,
+    "likes": 47752,
+    "dislikes": 409,
+    "comments": 3600,
+    "publishedDaysAgo": 771,
+    "lenSec": 470,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 29,
+    "title": "Bain de boue de l’éléphant",
+    "category": "Animaux",
+    "views": 862422,
+    "likes": 44701,
+    "dislikes": 368,
+    "comments": 412,
+    "publishedDaysAgo": 873,
+    "lenSec": 217,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 30,
+    "title": "Grimpe du panda roux",
+    "category": "Animaux",
+    "views": 357560,
+    "likes": 36209,
+    "dislikes": 438,
+    "comments": 3222,
+    "publishedDaysAgo": 269,
+    "lenSec": 1415,
+    "tags": [
+      "Animaux",
+      "train"
+    ]
+  },
+  {
+    "id": 31,
+    "title": "Le système solaire expliqué",
+    "category": "Sciences",
+    "views": 578384,
+    "likes": 35684,
+    "dislikes": 427,
+    "comments": 2332,
+    "publishedDaysAgo": 793,
+    "lenSec": 1760,
+    "tags": [
+      "Sciences",
+      "train",
+      "rec"
+    ]
+  },
+  {
+    "id": 32,
+    "title": "Pourquoi les plantes sont vertes",
+    "category": "Sciences",
+    "views": 982446,
+    "likes": 27350,
+    "dislikes": 402,
+    "comments": 2906,
+    "publishedDaysAgo": 935,
+    "lenSec": 353,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 33,
+    "title": "Physique des montagnes russes",
+    "category": "Sciences",
+    "views": 517367,
+    "likes": 31696,
+    "dislikes": 323,
+    "comments": 3513,
+    "publishedDaysAgo": 287,
+    "lenSec": 550,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 34,
+    "title": "Voyage dans le corps humain",
+    "category": "Sciences",
+    "views": 629159,
+    "likes": 1009,
+    "dislikes": 103,
+    "comments": 4273,
+    "publishedDaysAgo": 961,
+    "lenSec": 446,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 35,
+    "title": "Construire un circuit simple",
+    "category": "Sciences",
+    "views": 673868,
+    "likes": 40958,
+    "dislikes": 112,
+    "comments": 818,
+    "publishedDaysAgo": 712,
+    "lenSec": 273,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 36,
+    "title": "Cycle de l’eau illustré",
+    "category": "Sciences",
+    "views": 30865,
+    "likes": 12777,
+    "dislikes": 449,
+    "comments": 4391,
+    "publishedDaysAgo": 714,
+    "lenSec": 1195,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 37,
+    "title": "Bases du magnétisme",
+    "category": "Sciences",
+    "views": 17140,
+    "likes": 14574,
+    "dislikes": 279,
+    "comments": 2665,
+    "publishedDaysAgo": 328,
+    "lenSec": 940,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 38,
+    "title": "Les états de la matière",
+    "category": "Sciences",
+    "views": 450404,
+    "likes": 34613,
+    "dislikes": 410,
+    "comments": 4095,
+    "publishedDaysAgo": 40,
+    "lenSec": 946,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 39,
+    "title": "Documentaire sur les dinosaures",
+    "category": "Sciences",
+    "views": 296088,
+    "likes": 17409,
+    "dislikes": 355,
+    "comments": 2172,
+    "publishedDaysAgo": 734,
+    "lenSec": 965,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 40,
+    "title": "Introduction à l’électricité",
+    "category": "Sciences",
+    "views": 611283,
+    "likes": 47705,
+    "dislikes": 432,
+    "comments": 4832,
+    "publishedDaysAgo": 356,
+    "lenSec": 33,
+    "tags": [
+      "Sciences",
+      "train"
+    ]
+  },
+  {
+    "id": 41,
+    "title": "Guide débutant de l’île pixel",
+    "category": "Jeux vidéo",
+    "views": 508079,
+    "likes": 6244,
+    "dislikes": 344,
+    "comments": 3789,
+    "publishedDaysAgo": 696,
+    "lenSec": 285,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 42,
+    "title": "Course folle de kart arctique",
+    "category": "Jeux vidéo",
+    "views": 609807,
+    "likes": 24948,
+    "dislikes": 38,
+    "comments": 440,
+    "publishedDaysAgo": 581,
+    "lenSec": 1407,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 43,
+    "title": "Construction d’un monde en blocs",
+    "category": "Jeux vidéo",
+    "views": 921247,
+    "likes": 974,
+    "dislikes": 283,
+    "comments": 3504,
+    "publishedDaysAgo": 760,
+    "lenSec": 211,
+    "tags": [
+      "Jeux vidéo",
+      "train",
+      "rec"
+    ]
+  },
+  {
+    "id": 44,
+    "title": "Défi danse rythmique arcade",
+    "category": "Jeux vidéo",
+    "views": 631634,
+    "likes": 7552,
+    "dislikes": 393,
+    "comments": 4836,
+    "publishedDaysAgo": 292,
+    "lenSec": 647,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 45,
+    "title": "Stratégie conquête médiévale",
+    "category": "Jeux vidéo",
+    "views": 364558,
+    "likes": 29851,
+    "dislikes": 68,
+    "comments": 2396,
+    "publishedDaysAgo": 574,
+    "lenSec": 673,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 46,
+    "title": "Aventure RPG forêt enchantée",
+    "category": "Jeux vidéo",
+    "views": 421494,
+    "likes": 30898,
+    "dislikes": 351,
+    "comments": 4585,
+    "publishedDaysAgo": 435,
+    "lenSec": 346,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 47,
+    "title": "Match de soccer virtuel",
+    "category": "Jeux vidéo",
+    "views": 137343,
+    "likes": 15466,
+    "dislikes": 75,
+    "comments": 1803,
+    "publishedDaysAgo": 55,
+    "lenSec": 884,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 48,
+    "title": "Puzzle plateforme spatiale",
+    "category": "Jeux vidéo",
+    "views": 534553,
+    "likes": 4464,
+    "dislikes": 70,
+    "comments": 3207,
+    "publishedDaysAgo": 532,
+    "lenSec": 1012,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 49,
+    "title": "Course à obstacles néon",
+    "category": "Jeux vidéo",
+    "views": 341252,
+    "likes": 7358,
+    "dislikes": 413,
+    "comments": 4227,
+    "publishedDaysAgo": 446,
+    "lenSec": 194,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 50,
+    "title": "Simulation ferme canadienne",
+    "category": "Jeux vidéo",
+    "views": 769387,
+    "likes": 39357,
+    "dislikes": 78,
+    "comments": 582,
+    "publishedDaysAgo": 936,
+    "lenSec": 931,
+    "tags": [
+      "Jeux vidéo",
+      "train"
+    ]
+  },
+  {
+    "id": 51,
+    "title": "Bataille de robots rétro",
+    "category": "Jeux vidéo",
+    "views": 771977,
+    "likes": 19982,
+    "dislikes": 369,
+    "comments": 2662,
+    "publishedDaysAgo": 99,
+    "lenSec": 1090,
+    "tags": [
+      "Jeux vidéo",
+      "test"
+    ]
+  },
+  {
+    "id": 52,
+    "title": "Expérience œuf rebondissant",
+    "category": "Expériences",
+    "views": 124518,
+    "likes": 16828,
+    "dislikes": 390,
+    "comments": 4675,
+    "publishedDaysAgo": 988,
+    "lenSec": 453,
+    "tags": [
+      "Expériences",
+      "test"
+    ]
+  },
+  {
+    "id": 53,
+    "title": "Pourquoi avons‑nous des saisons",
+    "category": "Sciences",
+    "views": 335800,
+    "likes": 45444,
+    "dislikes": 117,
+    "comments": 1922,
+    "publishedDaysAgo": 500,
+    "lenSec": 1067,
+    "tags": [
+      "Sciences",
+      "test"
+    ]
+  },
+  {
+    "id": 54,
+    "title": "Premiers pas du koala",
+    "category": "Animaux",
+    "views": 430561,
+    "likes": 15101,
+    "dislikes": 408,
+    "comments": 842,
+    "publishedDaysAgo": 778,
+    "lenSec": 427,
+    "tags": [
+      "Animaux",
+      "test"
+    ]
+  }
+]

--- a/recommender.js
+++ b/recommender.js
@@ -1,0 +1,21 @@
+export async function loadData() {
+  const res = await fetch('public/data/videos.json');
+  const videos = await res.json();
+  const trainData = [];
+  const testData = [];
+  const recVid = {};
+  for (const v of videos) {
+    if (Array.isArray(v.tags)) {
+      if (v.tags.includes('train')) {
+        trainData.push({ title: v.title, label: v.category });
+      }
+      if (v.tags.includes('test')) {
+        testData.push({ title: v.title, label: v.category });
+      }
+      if (v.tags.includes('rec')) {
+        recVid[v.category] = v.title;
+      }
+    }
+  }
+  return { trainData, testData, recVid };
+}


### PR DESCRIPTION
## Summary
- Add `public/data/videos.json` storing video metadata for multiple categories.
- Introduce `recommender.js` with `loadData()` to build training and test sets from JSON.
- Update training pages to import the module and fetch data instead of using inline arrays.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689650c4b5308331adc79cb0473ebb14