### PR TITLE
Simplify dataset and automate challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ classiques (**âge**, **vidéo vue**, **catégorie**, **prédiction de la procha
 vidéo**) et ajoutent quatre indicateurs de popularité :
 
 - **vues** (popularité générale)
-- **ratio d'appréciation** (likes ÷ réactions)
+- **J'aime** (nombre de likes)
 - **commentaires** (niveau de controverse)
 - **publiée il y a (jours)** (récence)
 

--- a/page1.html
+++ b/page1.html
@@ -113,7 +113,7 @@
       <div class="options" id="options"></div>
     </div>
     <div class="data-panel">
-      <h2>Dataset</h2>
+      <h2>Ta table de données</h2>
       <table>
         <thead>
           <tr>
@@ -121,10 +121,6 @@
             <th>Vidéo vue</th>
             <th>Catégorie</th>
             <th>Prédiction</th>
-            <th>Vues</th>
-            <th>Ratio d'appréciation</th>
-            <th>Commentaires</th>
-            <th>Publiée il y a (jours)</th>
           </tr>
         </thead>
         <tbody id="dataset-body"></tbody>
@@ -175,13 +171,10 @@
     }
     function addPrediction(choice) {
       const q = questions[current];
-      const views = Math.floor(Math.random() * 500000) + 100;
-      const likeRatio = Math.random().toFixed(2);
-      const commentCount = Math.floor(Math.random() * 10000);
-      const publishedDaysAgo = Math.floor(Math.random() * 365);
       const row = document.createElement('tr');
-      row.innerHTML = `<td>${q.age}</td><td>${q.watched}</td><td>${q.category}</td><td>${choice}</td><td>${views}</td><td>${likeRatio}</td><td>${commentCount}</td><td>${publishedDaysAgo}</td>`;
-      row.classList.add('row-fade-in'); tbody.appendChild(row);
+      row.innerHTML = `<td>${q.age}</td><td>${q.watched}</td><td>${q.category}</td><td>${choice}</td>`;
+      row.classList.add('row-fade-in');
+      tbody.appendChild(row);
       current++;
       if (current < questions.length) setTimeout(renderQuestion,300);
       else {

--- a/page2.html
+++ b/page2.html
@@ -69,7 +69,7 @@
             <th>Catégorie</th>
             <th>Vidéo suivante</th>
             <th>Vues</th>
-            <th>Ratio d'appréciation</th>
+            <th>J'aime</th>
             <th>Commentaires</th>
             <th>Publiée il y a (jours)</th>
             <th>Action</th>
@@ -114,6 +114,31 @@
       row.classList.add('fade-out-row');
       row.addEventListener('animationend', () => row.remove());
     }
+    // Convert old "ratio" values to raw like counts on the fly (and leave weird values weird)
+    (function convertRatioToLikes(){
+      const table = document.querySelector('table');
+      if(!table || !table.tHead) return;
+      const headCells = table.tHead.rows[0].cells;
+      let idxLikeCol = -1, idxVues = -1;
+      for (let i=0;i<headCells.length;i++){
+        const t = headCells[i].textContent.trim().toLowerCase();
+        if (t === 'vues') idxVues = i;
+        if (t.includes("j'aime") || t.includes('ratio')) idxLikeCol = i;
+      }
+      if (idxLikeCol < 0 || idxVues < 0) return;
+      headCells[idxLikeCol].textContent = "J'aime";
+      const rows = [...table.tBodies[0].rows];
+      rows.forEach(r=>{
+        const vues = parseFloat(r.cells[idxVues].textContent.replace(/\s/g,'')) || 0;
+        const raw = r.cells[idxLikeCol].textContent.trim().replace(',', '.');
+        const ratio = parseFloat(raw);
+        if (!isNaN(ratio)) {
+          const likes = Math.round(vues * ratio);
+          // keep invalid results as-is (negative or > vues) so students can spot & clean them
+          r.cells[idxLikeCol].textContent = String(likes);
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/page3.html
+++ b/page3.html
@@ -215,51 +215,18 @@
     document.getElementById('addLeaf').onclick     = () => addNode('leaf');
     
 
-    // Linking logic
-    let origin = null, target = null, dragging = false;
-    const svgNS = "http://www.w3.org/2000/svg";
-    const svg = document.createElementNS(svgNS, 'svg');
-    svg.setAttribute('style', 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:5');
-    const defs = document.createElementNS(svgNS, 'defs');
-    const marker = document.createElementNS(svgNS, 'marker');
-    marker.setAttribute('id','arrowHead'); marker.setAttribute('markerWidth','6');
-    marker.setAttribute('markerHeight','6'); marker.setAttribute('refX','0');
-    marker.setAttribute('refY','3'); marker.setAttribute('orient','auto');
-    const path = document.createElementNS(svgNS,'path');
-    path.setAttribute('d','M0,0 L0,6 L6,3 z'); path.setAttribute('fill','#000');
-    marker.appendChild(path); defs.appendChild(marker); svg.appendChild(defs);
-    const line = document.createElementNS(svgNS,'line');
-    line.setAttribute('id','previewLine'); line.setAttribute('stroke','#000');
-    line.setAttribute('stroke-width','2'); line.setAttribute('marker-end','url(#arrowHead)');
-    line.setAttribute('visibility','hidden'); svg.appendChild(line);
-    document.getElementById('cy').appendChild(svg);
-
-    cy.on('cxttapstart','node', evt => {
-      origin = evt.target; dragging = false; target = null;
-      const p = origin.renderedPosition();
-      line.setAttribute('x1',p.x); line.setAttribute('y1',p.y);
-      line.setAttribute('x2',p.x); line.setAttribute('y2',p.y);
-      line.setAttribute('visibility','visible');
-    });
-    cy.on('cxtdrag', evt => {
-      if (!origin) return; dragging = true;
-      const rp = evt.renderedPosition; line.setAttribute('x2',rp.x); line.setAttribute('y2',rp.y);
-    });
-    cy.on('cxtdragover','node', evt => {
-      if (dragging && evt.target.id()!==origin.id()) target = evt.target;
-    });
-    cy.on('cxtdragout','node', evt => {
-      if (target && evt.target.id()===target.id()) target = null;
-    });
-    cy.on('cxttapend', () => {
-      line.setAttribute('visibility','hidden');
-      if (dragging && origin && target && origin.id()!==target.id()) {
+    // Linking logic: tap source → tap target
+    let linkStart = null;
+    cy.on('tap','node', evt => {
+      if (!linkStart) { linkStart = evt.target; return; }
+      const origin = linkStart, target = evt.target;
+      if (origin.id() !== target.id()) {
         const cnt = cy.edges().filter(e => e.source().id()===origin.id()).length;
         const lbl = cnt===0 ? 'oui' : cnt===1 ? 'non' : '';
-        cy.add({ group:'edges', data:{ id:'e'+nextEdgeId, source:origin.id(), target:target.id(), label:lbl } });
-        nextEdgeId++; saveState();
+        cy.add({ group:'edges', data:{ id:'e'+(nextEdgeId++), source:origin.id(), target:target.id(), label:lbl }});
+        saveState();
       }
-      origin = target = null; dragging = false;
+      linkStart = null;
     });
 
     // Inline editing

--- a/page5.html
+++ b/page5.html
@@ -113,7 +113,8 @@
 </head>
 <body>
   <div class="nav-bubble nav-left" onclick="navigate('page4.html')">◀</div>
-  <div class="nav-bubble nav-right" onclick="navigate('page6.html')">▶</div>
+  <!-- Fin de l’activité -->
+  <div class="nav-bubble nav-right" onclick="navigate('index.html')">▶</div>
   <h1 id="current-title"></h1>
   <div class="content">
     <div class="panel">
@@ -124,14 +125,7 @@
     <div class="panel">
       <h2>Arbre de Décision</h2>
       <div id="cy"></div>
-      
-      <div class="choices">
-        <button onclick="vote('Dessins')">Dessins</button>
-        <button onclick="vote('Expériences')">Expériences</button>
-        <button onclick="vote('Animaux')">Animaux</button>
-        <button onclick="vote('Sciences')">Sciences</button>
-        <button onclick="vote('Jeux vidéo')">Jeux vidéo</button>
-      </div>
+      <div id="tree-pred">Arbre propose : <em>(aucune)</em></div>
       <div class="counter">✅: <span id="user-correct">0</span></div>
     </div>
   </div>
@@ -178,15 +172,42 @@
       ],
       layout: { name: 'breadthfirst' }
     });
-    function loadTree() {
-      const hash = location.hash.slice(1);
-      if (!hash) return;
+    // Restore elements saved on page3 (location.hash, LZString)
+    (function loadState(){
+      const h = location.hash.slice(1); if (!h) return;
       try {
-        const elements = JSON.parse(LZString.decompressFromEncodedURIComponent(hash));
-        cy.add(elements);
-      } catch (e) { console.error('Failed to load tree from hash:', e); }
+        const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
+        if (Array.isArray(arr)) cy.add(arr);
+      } catch(e) {}
+    })();
+
+    // Simple evaluator for decision nodes:
+    // If a decision label contains words after ":" or inside quotes,
+    // we check if any of those words appear in the title.
+    function norm(s){ return (s||'').toLowerCase(); }
+    function testDecision(label, title){
+      const t = norm(title), q = norm(label);
+      // grab tokens after ":" or inside "quotes"
+      let words = [];
+      const after = q.includes(':') ? q.split(':').slice(1).join(':').trim() : '';
+      if (after) words = words.concat(after.split('|').map(w=>w.trim()).filter(Boolean));
+      const quoted = [...q.matchAll(/"([^"]+)"/g)].map(m=>m[1].trim());
+      if (quoted.length) words = words.concat(quoted);
+      return words.length ? words.some(w=> t.includes(w)) : false;
     }
-    loadTree();
+    function classifyWithTree(title){
+      // pick a root: first decision node with no incoming edges, else first node
+      let root = cy.nodes('.decision').filter(n=>n.incomers('edge').length===0)[0] || cy.nodes()[0];
+      let cur = root, guard = 0;
+      while(cur && cur.hasClass('decision') && guard++ < 50){
+        const cond = testDecision(cur.data('label'), title);
+        const edges = cur.outgoers('edge');
+        const next = edges.filter(e => (e.data('label')||'').toLowerCase()===(cond?'oui':'non'))[0];
+        cur = next ? next.target() : null;
+      }
+      if (cur && cur.hasClass('leaf')) return cur.data('label') || null;
+      return null;
+    }
 
     // --- Données d'entraînement et modèle ---
     function tokens(s){return s.toLowerCase().split(/[^a-zàâçéèêëîïôûùüÿñæœ]+/).filter(Boolean)}
@@ -262,7 +283,7 @@
       if(currentTest>=testData.length){
         document.getElementById('current-title').textContent='Fin des tests';
         document.getElementById('model-pred').textContent='Terminé';
-        document.querySelector('.choices').innerHTML='';
+        document.getElementById('tree-pred').textContent='Terminé';
         return;
       }
       const t=testData[currentTest];
@@ -271,13 +292,11 @@
       const suggestion=recVid[cat]||'Aucune';
       document.getElementById('model-pred').innerHTML=`Suggestion : <strong>${suggestion}</strong>`;
       if(cat===t.label){modelCorrect++;document.getElementById('model-correct').textContent=modelCorrect;}
-    }
-    function vote(cat){
-      if(currentTest>=testData.length)return;
-      const t=testData[currentTest];
-      if(cat===t.label){userCorrect++;document.getElementById('user-correct').textContent=userCorrect;}
+      const treeCat = classifyWithTree(t.title);
+      document.getElementById('tree-pred').innerHTML = `Arbre propose : <strong>${treeCat||'(aucune)'}</strong>`;
+      if(treeCat===t.label){userCorrect++;document.getElementById('user-correct').textContent=userCorrect;}
       currentTest++;
-      showTest();
+      setTimeout(showTest,2000);
     }
     showTest();
   </script>


### PR DESCRIPTION
## Summary
- Remove popularity fields from the dataset creation page and adjust UI wording
- Convert stored appreciation ratios into raw like counts for data cleaning
- Switch decision tree linking to tap-to-tap and auto-evaluate the saved tree during the challenge

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ff54fba0833185ee4806ffb1bcee