### PR TITLE
Make choices on page 5 visible

### DIFF
--- a/page5.html
+++ b/page5.html
@@ -8,7 +8,7 @@
     body {
       margin: 0; padding: 0; font-family: Verdana, sans-serif;
       background: linear-gradient(to bottom, #5bc0eb, #20639b);
-      height: 100vh; overflow: hidden; position: relative;
+      min-height: 100vh; overflow-x: hidden; overflow-y: auto; position: relative;
       display: flex; flex-direction: column;
       opacity: 0; animation: fadeIn 0.5s ease forwards;
     }
@@ -42,12 +42,12 @@
       color: white;
       display: flex;
       flex-direction: column;
-      overflow: hidden;
+      overflow-y: auto;
       box-shadow: 0 4px 10px rgba(0,0,0,0.2);
     }
 
     .panel h2 { margin-top: 0; font-size: 1.4rem; border-bottom: 1px solid rgba(255,255,255,0.3); padding-bottom: .5rem; margin-bottom: 1rem; }
-    #cy { flex: 1; background: #fff; border-radius: 8px; min-height: 260px; }
+    #cy { flex: 0 0 260px; background: #fff; border-radius: 8px; }
     .counter { margin-top: .5rem; font-size: .95rem; }
     /* NEW: 4-card choice grid */
     .options-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .75rem; margin-top: .75rem; }


### PR DESCRIPTION
## Summary
- ensure page 5 content can scroll and stays within the viewport
- keep Cytoscape panel at fixed height so option grid remains visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a191c05a48331a67b538d9e797287