### PR TITLE
Fix tree visualization layout and resizing

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -154,31 +154,50 @@
       style: [
         { selector: 'node', style: {
             'label': 'data(label)',
-            'text-valign': 'center', 'text-halign': 'center',
-            'color': '#fff', 'width': 'label', 'height': 50,
+            'text-valign': 'center',
+            'text-halign': 'center',
+            'color': '#fff',
+            'width': 'label',
+            'height': 50,
             'background-color': '#666'
           }
         },
         { selector: '.decision', style: {
-            'shape': 'diamond', 'background-color': '#4CAF50', 'padding': '30px'
+            'shape': 'diamond',
+            'background-color': '#4CAF50',
+            'padding': '30px'
           }
         },
         { selector: '.leaf', style: {
-            'shape': 'roundrectangle', 'background-color': '#2196F3', 'padding': '10px'
+            'shape': 'roundrectangle',
+            'background-color': '#2196F3',
+            'padding': '10px'
           }
         },
         { selector: 'edge', style: {
-            'width': 2, 'line-color': '#000', 'target-arrow-shape': 'triangle',
-            'target-arrow-color': '#000', 'arrow-scale': 1.2, 'curve-style': 'bezier',
-            'label': 'data(label)', 'text-margin-y': -10,
-            'text-background-opacity': 1, 'text-background-color': '#fff',
-            'text-background-shape': 'roundrectangle', 'text-background-padding': 2,
-            'font-size': 12, 'text-rotation': 'autorotate'
+            'width': 2,
+            'line-color': '#000',
+            'target-arrow-shape': 'triangle',
+            'target-arrow-color': '#000',
+            'arrow-scale': 1.2,
+            'curve-style': 'bezier',
+            'label': 'data(label)',
+            'text-margin-y': -10,
+            'text-background-opacity': 1,
+            'text-background-color': '#fff',
+            'text-background-shape': 'roundrectangle',
+            'text-background-padding': 2,
+            'font-size': 12,
+            'text-rotation': 'autorotate'
           }
         }
       ],
       layout: { name: 'preset' }
     });
+    const cyEl = document.getElementById('cy');
+    new ResizeObserver(() => cy.resize()).observe(cyEl);
+    requestAnimationFrame(() => { cy.resize(); cy.fit(null, 20); });
+    window.addEventListener('resize', () => cy.resize());
 
     let nextNodeId = 0, nextEdgeId = 0;
     function saveState() {
@@ -192,10 +211,16 @@
       history.replaceState(null, '', '#' + comp);
     }
     function loadState() {
-      const h = location.hash.slice(1); if (!h) return;
+      const h = location.hash.slice(1);
+      if (!h) return;
       try {
         const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
-        cy.elements().remove(); cy.add(arr);
+        cy.elements().remove();
+        cy.add(arr);
+        const hasPos = Array.isArray(arr) && arr.some(e => e.group === 'nodes' && e.position);
+        if (!hasPos) cy.layout({ name: 'breadthfirst', directed: true, padding: 24 }).run();
+        cy.fit(null, 20);
+        cy.resize();
         const nIds = cy.nodes().map(n => +n.id().slice(1)).filter(x=>!isNaN(x));
         const eIds = cy.edges().map(e => +e.id().slice(1)).filter(x=>!isNaN(x));
         nextNodeId = nIds.length ? Math.max(...nIds)+1 : 0;

--- a/page5.html
+++ b/page5.html
@@ -48,7 +48,7 @@
 
     .panel h2 { margin-top: 0; font-size: 1.4rem; border-bottom: 1px solid rgba(255,255,255,0.3); padding-bottom: .5rem; margin-bottom: 1rem; }
 
-    #cy { flex: 1 1 auto; min-height: 0; background: #fff; border-radius: 8px; }
+    #cy { flex: 1 1 auto; min-height: 0; background: #fff; border-radius: 0; }
 
     .counter { margin-top: .5rem; font-size: .95rem; }
     .bottom { margin-top: auto; display: flex; flex-direction: column; gap: .75rem; }
@@ -134,36 +134,62 @@
       elements: [],
       style: [
         { selector: 'node', style: {
-            'label': 'data(label)', 'text-valign': 'center', 'text-halign': 'center',
-            'color': '#fff', 'width': 'label', 'height': 50,
+            'label': 'data(label)',
+            'text-valign': 'center',
+            'text-halign': 'center',
+            'color': '#fff',
+            'width': 'label',
+            'height': 50,
             'background-color': '#666'
           }
         },
         { selector: '.decision', style: {
-            'shape': 'diamond', 'background-color': '#4CAF50'
+            'shape': 'diamond',
+            'background-color': '#4CAF50',
+            'padding': '30px'
           }
         },
         { selector: '.leaf', style: {
-            'shape': 'roundrectangle', 'background-color': '#2196F3'
+            'shape': 'roundrectangle',
+            'background-color': '#2196F3',
+            'padding': '10px'
           }
         },
         { selector: 'edge', style: {
-            'width': 2, 'line-color': '#000', 'target-arrow-shape': 'triangle',
-            'target-arrow-color': '#000', 'arrow-scale': 1.2, 'curve-style': 'bezier',
-            'label': 'data(label)', 'text-background-opacity': 1,
-            'text-background-color': '#fff', 'text-background-shape': 'roundrectangle',
-            'text-background-padding': 2, 'font-size': 12, 'text-rotation': 'autorotate'
+            'width': 2,
+            'line-color': '#000',
+            'target-arrow-shape': 'triangle',
+            'target-arrow-color': '#000',
+            'arrow-scale': 1.2,
+            'curve-style': 'bezier',
+            'label': 'data(label)',
+            'text-background-opacity': 1,
+            'text-background-color': '#fff',
+            'text-background-shape': 'roundrectangle',
+            'text-background-padding': 2,
+            'font-size': 12,
+            'text-rotation': 'autorotate'
           }
         }
       ],
-      layout: { name: 'breadthfirst' }
+      layout: { name: 'preset' }
     });
-    // Restore elements saved on page3 (location.hash, LZString)
+    const cyEl = document.getElementById('cy');
+    new ResizeObserver(() => cy.resize()).observe(cyEl);
+    requestAnimationFrame(() => { cy.resize(); cy.fit(null, 20); });
+    window.addEventListener('resize', () => cy.resize());
     (function loadState(){
-      const h = location.hash.slice(1); if (!h) return;
+      const h = location.hash.slice(1);
+      if (!h) return;
       try {
         const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
-        if (Array.isArray(arr)) cy.add(arr);
+        if (Array.isArray(arr) && arr.length) {
+          cy.add(arr);
+          const hasPos = arr.some(e => e.group === 'nodes' && e.position);
+          if (!hasPos) cy.layout({ name: 'breadthfirst', directed: true, padding: 24 }).run();
+          cy.fit(null, 20);
+          cy.resize();
+        }
       } catch(e) {}
     })();
 


### PR DESCRIPTION
## Summary
- Ensure tree panel uses a neutral border and preset layout with padding for decision and leaf nodes.
- Add resize observers and fit graph after loading nodes on “Arbre de Décision” and “Créateur d’Arbre” pages.
- Rework state-loading logic to run breadthfirst layout when positions missing and track node/edge IDs.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3c12b9188331a87dd6a62fdeef78