### PR TITLE
Fix graph loading and auto-fit behavior

### DIFF
--- a/page3.html
+++ b/page3.html
@@ -220,11 +220,12 @@
       try {
         const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
         cy.elements().remove();
-        cy.add(arr);
-        const hasPos = Array.isArray(arr) && arr.some(e => e.group === 'nodes' && e.position);
+        const nodes = Array.isArray(arr) ? arr.filter(e => e.group === 'nodes') : [];
+        const edges = Array.isArray(arr) ? arr.filter(e => e.group === 'edges') : [];
+        cy.add(nodes);
+        cy.add(edges);
+        const hasPos = nodes.some(e => e.position);
         if (!hasPos) cy.layout({ name: 'breadthfirst', directed: true, padding: 24 }).run();
-        cy.fit(null, 20);
-        cy.resize();
         const nIds = cy.nodes().map(n => +n.id().slice(1)).filter(x=>!isNaN(x));
         const eIds = cy.edges().map(e => +e.id().slice(1)).filter(x=>!isNaN(x));
         nextNodeId = nIds.length ? Math.max(...nIds)+1 : 0;
@@ -317,8 +318,6 @@
           }
         });
         nextEdgeId++;
-        cy.fit(null, 20);
-        cy.resize();
         saveState();
       }
       linkOrigin = linkTarget = null;

--- a/page5.html
+++ b/page5.html
@@ -188,8 +188,11 @@
       try {
         const arr = JSON.parse(LZString.decompressFromEncodedURIComponent(h));
         if (Array.isArray(arr) && arr.length) {
-          cy.add(arr);
-          const hasPos = arr.some(e => e.group === 'nodes' && e.position);
+          const nodes = arr.filter(e => e.group === 'nodes');
+          const edges = arr.filter(e => e.group === 'edges');
+          cy.add(nodes);
+          cy.add(edges);
+          const hasPos = nodes.some(e => e.position);
           if (!hasPos) cy.layout({ name: 'breadthfirst', directed: true, padding: 24 }).run();
           cy.fit(null, 20);
           cy.resize();


### PR DESCRIPTION
## Summary
- Load decision tree nodes before edges so existing edges render correctly
- Stop auto-fitting the graph on the editor page while keeping it on the results page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b668f61ac8331b58fe8f8f1879915